### PR TITLE
Flush database to disk regularly

### DIFF
--- a/fossilize_db.cpp
+++ b/fossilize_db.cpp
@@ -51,6 +51,10 @@ struct DumbDirectoryDatabase : DatabaseInterface
 			mode = DatabaseMode::OverWrite;
 	}
 
+	void flush() override
+	{
+	}
+
 	bool prepare() override
 	{
 		if (mode == DatabaseMode::OverWrite)
@@ -234,6 +238,10 @@ struct ZipDatabase : DatabaseInterface
 			if (!mz_zip_end(&mz))
 				LOGE("mz_zip_end failed!\n");
 		}
+	}
+
+	void flush() override
+	{
 	}
 
 	static bool string_is_hex(const char *str)
@@ -476,6 +484,12 @@ struct StreamArchive : DatabaseInterface
 		free(zlib_buffer);
 		if (file)
 			fclose(file);
+	}
+
+	void flush() override
+	{
+		if (file && mode != DatabaseMode::ReadOnly)
+			fflush(file);
 	}
 
 	bool prepare() override
@@ -951,6 +965,12 @@ struct ConcurrentDatabase : DatabaseInterface
 	{
 		delete readonly_interface;
 		delete writeonly_interface;
+	}
+
+	void flush() override
+	{
+		if (writeonly_interface)
+			writeonly_interface->flush();
 	}
 
 	bool prepare() override

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -102,6 +102,9 @@ public:
 
 	// Arguments are similar to Vulkan, call the query function twice.
 	virtual bool get_hash_list_for_resource_tag(ResourceTag tag, size_t *num_hashes, Hash *hash) = 0;
+
+	// Ensures all file writes are flushed, ala fflush(). Might be noop depending on the implementation.
+	virtual void flush() = 0;
 };
 
 enum class DatabaseMode


### PR DESCRIPTION
While recording, we need to call fflush to make sure that uncommon exits flush the written data to disk. Apparently, DXVK through Wine/Proton does not flush file handles before exiting the process.

To avoid hammering fflush every few kBs of data, we wait for the recording thread to go idle for a second, which triggers the flush and goes back to deep sleep again.

This fixed the sliced database issue for me on INSIDE at least.

If we see this issue even with this timeout, we might need to go full fflush always, hopefully it doesn't get to that.

I also added logging to easier detect such sliced databases.