### PR TITLE
Use a 40-hex char length for blob hash name.

### DIFF
--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -829,7 +829,7 @@ struct ThreadedReplayer : StateCreatorInterface
 	VulkanDevice::Options device_opts;
 
 	// Crash recovery.
-	Hash failed_module_hashes[6];
+	Hash failed_module_hashes[6] = {};
 	unsigned num_failed_module_hashes = 0;
 	unsigned thread_current_graphics_index = 0;
 	unsigned thread_current_compute_index = 0;

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -75,7 +75,7 @@ struct ProcessProgress
 	HANDLE timer_handle = nullptr;
 	HANDLE pipe_event = nullptr;
 
-	OVERLAPPED overlapped_pipe;
+	OVERLAPPED overlapped_pipe = {};
 	char async_pipe_buffer[1024];
 
 	int compute_progress = -1;

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -37,7 +37,7 @@ namespace Fossilize
 {
 enum
 {
-	FOSSILIZE_FORMAT_VERSION = 4
+	FOSSILIZE_FORMAT_VERSION = 5
 };
 
 class DatabaseInterface;


### PR DESCRIPTION
This is so the format can be reused for other purposes where SHA-1 hash
is typically used.