### PR TITLE
Improve pipelining when replaying datasets with derivative pipelines

### DIFF
--- a/cli/fossilize_bench.cpp
+++ b/cli/fossilize_bench.cpp
@@ -181,7 +181,7 @@ static void bench_recorder(const char *path, bool compressed, bool checksum)
 		VkPipelineViewportStateCreateInfo vp = { VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO };
 		info.pViewportState = &vp;
 
-		recorder.record_graphics_pipeline((VkPipeline)uint64_t(i + 1), info);
+		recorder.record_graphics_pipeline((VkPipeline)uint64_t(i + 1), info, nullptr, 0);
 	}
 }
 

--- a/cli/fossilize_opt.cpp
+++ b/cli/fossilize_opt.cpp
@@ -86,14 +86,14 @@ struct OptimizeReplayer : StateCreatorInterface
 	bool enqueue_create_compute_pipeline(Hash hash, const VkComputePipelineCreateInfo *create_info, VkPipeline *pipeline) override
 	{
 		*pipeline = fake_handle<VkPipeline>(hash);
-		recorder.record_compute_pipeline(*pipeline, *create_info);
+		recorder.record_compute_pipeline(*pipeline, *create_info, nullptr, 0);
 		return true;
 	}
 
 	bool enqueue_create_graphics_pipeline(Hash hash, const VkGraphicsPipelineCreateInfo *create_info, VkPipeline *pipeline) override
 	{
 		*pipeline = fake_handle<VkPipeline>(hash);
-		recorder.record_graphics_pipeline(*pipeline, *create_info);
+		recorder.record_graphics_pipeline(*pipeline, *create_info, nullptr, 0);
 		return true;
 	}
 };

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -127,6 +127,13 @@ public:
 	StateReplayer();
 	~StateReplayer();
 	void parse(StateCreatorInterface &iface, DatabaseInterface *database, const void *buffer, size_t size);
+
+	// Default is true. If true, the replayer will make sure the derivative pipeline handles provided to
+	// the API is a correct VkPipeline. If false, pipelines with VK_PIPELINE_CREATE_DERIVATIVE_BIT will have its basePipelineHandle
+	// set to the hash of the pipeline. It is up to the caller to resolve this hash to a real pipeline later.
+	// Setting to false can help improve replay performance in multi-threaded scenarios.
+	void set_resolve_derivative_pipeline_handles(bool enable);
+
 	ScratchAllocator &get_allocator();
 
 	// Disable copies (and moves).
@@ -170,8 +177,10 @@ public:
 	void record_descriptor_set_layout(VkDescriptorSetLayout set_layout, const VkDescriptorSetLayoutCreateInfo &layout_info);
 	void record_pipeline_layout(VkPipelineLayout pipeline_layout, const VkPipelineLayoutCreateInfo &layout_info);
 	void record_shader_module(VkShaderModule module, const VkShaderModuleCreateInfo &create_info);
-	void record_graphics_pipeline(VkPipeline pipeline, const VkGraphicsPipelineCreateInfo &create_info);
-	void record_compute_pipeline(VkPipeline pipeline, const VkComputePipelineCreateInfo &create_info);
+	void record_graphics_pipeline(VkPipeline pipeline, const VkGraphicsPipelineCreateInfo &create_info,
+	                              const VkPipeline *base_pipelines, uint32_t base_pipeline_count);
+	void record_compute_pipeline(VkPipeline pipeline, const VkComputePipelineCreateInfo &create_info,
+	                             const VkPipeline *base_pipelines, uint32_t base_pipeline_count);
 	void record_render_pass(VkRenderPass render_pass, const VkRenderPassCreateInfo &create_info);
 	void record_sampler(VkSampler sampler, const VkSamplerCreateInfo &create_info);
 

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -299,7 +299,8 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 			argv.push_back(self_path.c_str());
 		argv.push_back(options.database);
 		argv.push_back("--master-process");
-		argv.push_back("--quiet-slave");
+		if (options.quiet)
+			argv.push_back("--quiet-slave");
 		argv.push_back("--shmem-fd");
 		argv.push_back(fd_name);
 

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -240,7 +240,8 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	cmdline += options.database;
 	cmdline += "\"";
 	cmdline += " --master-process";
-	cmdline += " --quiet-slave";
+	if (options.quiet)
+		cmdline += " --quiet-slave";
 	cmdline += " --shm-name ";
 	cmdline += shm_name;
 	cmdline += " --shm-mutex-name ";

--- a/layer/dispatch.cpp
+++ b/layer/dispatch.cpp
@@ -148,24 +148,22 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, V
 {
 	auto *layer = get_device_layer(device);
 
+	// Have to create all pipelines here, in case the application makes use of basePipelineIndex.
+	auto res = layer->getTable()->CreateGraphicsPipelines(layer->getDevice(), pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+	if (res != VK_SUCCESS)
+		return res;
+
 	for (uint32_t i = 0; i < createInfoCount; i++)
 	{
-		auto res = layer->getTable()->CreateGraphicsPipelines(layer->getDevice(), pipelineCache, 1, &pCreateInfos[i], pAllocator, &pPipelines[i]);
-
-		if (res == VK_SUCCESS)
+		try
 		{
-			try
-			{
-				// Record methods may throw on unexpected input. We cannot propagate this error up.
-				layer->getRecorder().record_graphics_pipeline(pPipelines[i], pCreateInfos[i]);
-			}
-			catch (const std::exception &e)
-			{
-				LOGE("Failed to record graphics pipeline: %s\n", e.what());
-			}
+			// Record methods may throw on unexpected input. We cannot propagate this error up.
+			layer->getRecorder().record_graphics_pipeline(pPipelines[i], pCreateInfos[i], pPipelines, createInfoCount);
 		}
-		else
-			return res;
+		catch (const std::exception &e)
+		{
+			LOGE("Failed to record graphics pipeline: %s\n", e.what());
+		}
 	}
 
 	return VK_SUCCESS;
@@ -179,24 +177,22 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, Vk
 {
 	auto *layer = get_device_layer(device);
 
+	// Have to create all pipelines here, in case the application makes use of basePipelineIndex.
+	auto res = layer->getTable()->CreateComputePipelines(layer->getDevice(), pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+	if (res != VK_SUCCESS)
+		return res;
+
 	for (uint32_t i = 0; i < createInfoCount; i++)
 	{
-		auto res = layer->getTable()->CreateComputePipelines(layer->getDevice(), pipelineCache, 1, &pCreateInfos[i], pAllocator, &pPipelines[i]);
-
-		if (res == VK_SUCCESS)
+		try
 		{
-			try
-			{
-				// Record methods may throw on unexpected input. We cannot propagate this error up.
-				layer->getRecorder().record_compute_pipeline(pPipelines[i], pCreateInfos[i]);
-			}
-			catch (const std::exception &e)
-			{
-				LOGE("Failed to record compute pipeline: %s\n", e.what());
-			}
+			// Record methods may throw on unexpected input. We cannot propagate this error up.
+			layer->getRecorder().record_compute_pipeline(pPipelines[i], pCreateInfos[i], pPipelines, createInfoCount);
 		}
-		else
-			return res;
+		catch (const std::exception &e)
+		{
+			LOGE("Failed to record compute pipeline: %s\n", e.what());
+		}
 	}
 
 	return VK_SUCCESS;

--- a/test/fossilize_test.cpp
+++ b/test/fossilize_test.cpp
@@ -120,7 +120,7 @@ struct ReplayInterface : StateCreatorInterface
 			return false;
 
 		*pipeline = fake_handle<VkPipeline>(hash);
-		recorder.record_compute_pipeline(*pipeline, *create_info);
+		recorder.record_compute_pipeline(*pipeline, *create_info, nullptr, 0);
 		return true;
 	}
 
@@ -131,7 +131,7 @@ struct ReplayInterface : StateCreatorInterface
 			return false;
 
 		*pipeline = fake_handle<VkPipeline>(hash);
-		recorder.record_graphics_pipeline(*pipeline, *create_info);
+		recorder.record_graphics_pipeline(*pipeline, *create_info, nullptr, 0);
 		return true;
 	}
 };
@@ -324,12 +324,12 @@ static void record_compute_pipelines(StateRecorder &recorder)
 	pipe.stage.pSpecializationInfo = &spec;
 	pipe.layout = fake_handle<VkPipelineLayout>(10001);
 
-	recorder.record_compute_pipeline(fake_handle<VkPipeline>(80000), pipe);
+	recorder.record_compute_pipeline(fake_handle<VkPipeline>(80000), pipe, nullptr, 0);
 
 	//pipe.basePipelineHandle = fake_handle<VkPipeline>(80000);
 	pipe.basePipelineIndex = 10;
 	pipe.stage.pSpecializationInfo = nullptr;
-	recorder.record_compute_pipeline(fake_handle<VkPipeline>(80001), pipe);
+	recorder.record_compute_pipeline(fake_handle<VkPipeline>(80001), pipe, nullptr, 0);
 }
 
 static void record_graphics_pipelines(StateRecorder &recorder)
@@ -497,13 +497,13 @@ static void record_graphics_pipelines(StateRecorder &recorder)
 	pipe.pRasterizationState = &rs;
 	pipe.pInputAssemblyState = &ia;
 
-	recorder.record_graphics_pipeline(fake_handle<VkPipeline>(100000), pipe);
+	recorder.record_graphics_pipeline(fake_handle<VkPipeline>(100000), pipe, nullptr, 0);
 
 	vp.viewportCount = 0;
 	vp.scissorCount = 0;
 	pipe.basePipelineHandle = fake_handle<VkPipeline>(100000);
 	pipe.basePipelineIndex = 200;
-	recorder.record_graphics_pipeline(fake_handle<VkPipeline>(100001), pipe);
+	recorder.record_graphics_pipeline(fake_handle<VkPipeline>(100001), pipe, nullptr, 0);
 }
 
 static bool test_database()


### PR DESCRIPTION
DXVK uses derivative pipelines when replaying. Reorder replaying order to avoid hard stalls in the replayer threads. Also, fix a bug with recording of derived pipelines. If basePipelineIndex was used, this would not be replayable, but DXVK didn't seem to make use of that feature.