### PR TITLE
Implement threaded parsing and decompression

### DIFF
--- a/cli/fossilize_prune.cpp
+++ b/cli/fossilize_prune.cpp
@@ -255,6 +255,8 @@ int main(int argc, char *argv[])
 	StateReplayer replayer;
 	PruneReplayer prune_replayer;
 
+	replayer.set_resolve_shader_module_handles(false);
+
 	if (should_filter_application_hash)
 	{
 		prune_replayer.should_filter_application_hash = true;
@@ -262,14 +264,14 @@ int main(int argc, char *argv[])
 	}
 
 	static const ResourceTag playback_order[] = {
-		RESOURCE_APPLICATION_INFO, // This will create the device, etc.
-		RESOURCE_SHADER_MODULE, // Kick off shader modules first since it can be done in a thread while we deal with trivial objects.
-		RESOURCE_SAMPLER, // Trivial, run in main thread.
-		RESOURCE_DESCRIPTOR_SET_LAYOUT, // Trivial, run in main thread
-		RESOURCE_PIPELINE_LAYOUT, // Trivial, run in main thread
-		RESOURCE_RENDER_PASS, // Trivial, run in main thread
-		RESOURCE_GRAPHICS_PIPELINE, // Multi-threaded
-		RESOURCE_COMPUTE_PIPELINE, // Multi-threaded
+		RESOURCE_APPLICATION_INFO,
+		RESOURCE_SHADER_MODULE,
+		RESOURCE_SAMPLER,
+		RESOURCE_DESCRIPTOR_SET_LAYOUT,
+		RESOURCE_PIPELINE_LAYOUT,
+		RESOURCE_RENDER_PASS,
+		RESOURCE_GRAPHICS_PIPELINE,
+		RESOURCE_COMPUTE_PIPELINE,
 	};
 
 	unsigned per_tag_read[RESOURCE_COUNT] = {};
@@ -290,6 +292,10 @@ int main(int argc, char *argv[])
 
 	for (auto &tag : playback_order)
 	{
+		// No need to resolve this type.
+		if (tag == RESOURCE_SHADER_MODULE)
+			continue;
+
 		prune_replayer.allow_application_info = tag == RESOURCE_APPLICATION_INFO;
 
 		size_t hash_count = 0;

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -1305,6 +1305,7 @@ static int run_progress_process(const VulkanDevice::Options &,
 	opts.quiet = true;
 	opts.database = db_path.c_str();
 	opts.external_replayer_path = nullptr;
+	opts.inherit_process_group = true;
 
 	ExternalReplayer replayer;
 	if (!replayer.start(opts))

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -858,6 +858,10 @@ struct ThreadedReplayer : StateCreatorInterface
 		// us to pipeline parsing with pipeline compilation.
 		if (!derived)
 			compute_pipeline_index++;
+
+		if (opts.control_block)
+			opts.control_block->parsed_compute.fetch_add(1, std::memory_order_relaxed);
+
 		return true;
 	}
 
@@ -901,6 +905,9 @@ struct ThreadedReplayer : StateCreatorInterface
 		// us to pipeline parsing with pipeline compilation.
 		if (!derived)
 			graphics_pipeline_index++;
+
+		if (opts.control_block)
+			opts.control_block->parsed_graphics.fetch_add(1, std::memory_order_relaxed);
 
 		return true;
 	}
@@ -1263,9 +1270,11 @@ static void log_progress(const ExternalReplayer::Progress &progress)
 {
 	LOGI("=================\n");
 	LOGI(" Progress report:\n");
-	LOGI("   Graphics %u / %u, skipped %u\n", progress.graphics.completed, progress.graphics.total, progress.graphics.skipped);
-	LOGI("   Compute %u / %u, skipped %u\n", progress.compute.completed, progress.compute.total, progress.compute.skipped);
-	LOGI("   Modules %u / %u, skipped %u\n", progress.completed_modules, progress.total_modules, progress.banned_modules);
+	LOGI("   Parsed graphics %u / %u\n", progress.graphics.parsed, progress.graphics.total);
+	LOGI("   Parsed compute %u / %u\n", progress.compute.parsed, progress.compute.total);
+	LOGI("   Decompress modules %u / %u, skipped %u\n", progress.completed_modules, progress.total_modules, progress.banned_modules);
+	LOGI("   Compile graphics %u / %u, skipped %u\n", progress.graphics.completed, progress.graphics.total, progress.graphics.skipped);
+	LOGI("   Compile compute %u / %u, skipped %u\n", progress.compute.completed, progress.compute.total, progress.compute.skipped);
 	LOGI("   Clean crashes %u\n", progress.clean_crashes);
 	LOGI("   Dirty crashes %u\n", progress.dirty_crashes);
 	LOGI("=================\n");

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -363,7 +363,7 @@ struct ThreadedReplayer : StateCreatorInterface
 
 					*work_item.hash_map_entry.pipeline = *work_item.output.pipeline;
 
-					if (opts.control_block && i == 0 && work_item.contributes_to_index)
+					if (opts.control_block && i == 0)
 						opts.control_block->successful_graphics.fetch_add(1, std::memory_order_relaxed);
 				}
 				else
@@ -434,7 +434,7 @@ struct ThreadedReplayer : StateCreatorInterface
 
 					*work_item.hash_map_entry.pipeline = *work_item.output.pipeline;
 
-					if (opts.control_block && i == 0 && work_item.contributes_to_index)
+					if (opts.control_block && i == 0)
 						opts.control_block->successful_compute.fetch_add(1, std::memory_order_relaxed);
 				}
 				else
@@ -837,7 +837,8 @@ struct ThreadedReplayer : StateCreatorInterface
 		         compute_pipeline_index < opts.end_compute_index)
 		{
 			lock_guard<mutex> lock(internal_enqueue_mutex);
-			deferred_compute.push_back({ const_cast<VkComputePipelineCreateInfo *>(create_info), hash, pipeline, true });
+			// Does not contribute further to the pipeline index since we're incrementing it here.
+			deferred_compute.push_back({ const_cast<VkComputePipelineCreateInfo *>(create_info), hash, pipeline, false });
 		}
 		else
 		{
@@ -879,7 +880,8 @@ struct ThreadedReplayer : StateCreatorInterface
 		         graphics_pipeline_index < opts.end_graphics_index)
 		{
 			lock_guard<mutex> lock(internal_enqueue_mutex);
-			deferred_graphics.push_back({ const_cast<VkGraphicsPipelineCreateInfo *>(create_info), hash, pipeline, true });
+			// Does not contribute further to the pipeline index since we're incrementing it here.
+			deferred_graphics.push_back({ const_cast<VkGraphicsPipelineCreateInfo *>(create_info), hash, pipeline, false });
 		}
 		else
 		{

--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -414,7 +414,6 @@ static int run_master_process(const VulkanDevice::Options &opts,
 	{
 		Global::control_block->total_graphics.store(num_graphics_pipelines, std::memory_order_relaxed);
 		Global::control_block->total_compute.store(num_compute_pipelines, std::memory_order_relaxed);
-		Global::control_block->total_modules.store(num_modules, std::memory_order_relaxed);
 		Global::control_block->progress_started.store(true, std::memory_order_release);
 	}
 

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -600,7 +600,6 @@ static int run_master_process(const VulkanDevice::Options &opts,
 	{
 		Global::control_block->total_graphics.store(num_graphics_pipelines, std::memory_order_relaxed);
 		Global::control_block->total_compute.store(num_compute_pipelines, std::memory_order_relaxed);
-		Global::control_block->total_modules.store(num_modules, std::memory_order_relaxed);
 		Global::control_block->progress_started.store(true, std::memory_order_release);
 	}
 

--- a/fossilize.cpp
+++ b/fossilize.cpp
@@ -2135,15 +2135,15 @@ void StateReplayer::copy_handle_references(const StateReplayer &replayer)
 	impl->copy_handle_references(*replayer.impl);
 }
 
-void StateReplayer::Impl::copy_handle_references(const StateReplayer::Impl &impl)
+void StateReplayer::Impl::copy_handle_references(const StateReplayer::Impl &other)
 {
-	replayed_samplers = impl.replayed_samplers;
-	replayed_descriptor_set_layouts = impl.replayed_descriptor_set_layouts;
-	replayed_pipeline_layouts = impl.replayed_pipeline_layouts;
-	replayed_shader_modules = impl.replayed_shader_modules;
-	replayed_render_passes = impl.replayed_render_passes;
-	replayed_compute_pipelines = impl.replayed_compute_pipelines;
-	replayed_graphics_pipelines = impl.replayed_graphics_pipelines;
+	replayed_samplers = other.replayed_samplers;
+	replayed_descriptor_set_layouts = other.replayed_descriptor_set_layouts;
+	replayed_pipeline_layouts = other.replayed_pipeline_layouts;
+	replayed_shader_modules = other.replayed_shader_modules;
+	replayed_render_passes = other.replayed_render_passes;
+	replayed_compute_pipelines = other.replayed_compute_pipelines;
+	replayed_graphics_pipelines = other.replayed_graphics_pipelines;
 }
 
 void StateReplayer::Impl::parse(StateCreatorInterface &iface, DatabaseInterface *resolver, const void *buffer_, size_t total_size)

--- a/fossilize.cpp
+++ b/fossilize.cpp
@@ -149,6 +149,7 @@ struct StateReplayer::Impl
 	std::unordered_map<Hash, VkPipeline> replayed_compute_pipelines;
 	std::unordered_map<Hash, VkPipeline> replayed_graphics_pipelines;
 
+	void copy_handle_references(const Impl &impl);
 	void parse_samplers(StateCreatorInterface &iface, const Value &samplers);
 	void parse_descriptor_set_layouts(StateCreatorInterface &iface, const Value &layouts);
 	void parse_pipeline_layouts(StateCreatorInterface &iface, const Value &layouts);
@@ -2127,6 +2128,22 @@ void StateReplayer::set_resolve_derivative_pipeline_handles(bool enable)
 void StateReplayer::set_resolve_shader_module_handles(bool enable)
 {
 	impl->resolve_shader_modules = enable;
+}
+
+void StateReplayer::copy_handle_references(const StateReplayer &replayer)
+{
+	impl->copy_handle_references(*replayer.impl);
+}
+
+void StateReplayer::Impl::copy_handle_references(const StateReplayer::Impl &impl)
+{
+	replayed_samplers = impl.replayed_samplers;
+	replayed_descriptor_set_layouts = impl.replayed_descriptor_set_layouts;
+	replayed_pipeline_layouts = impl.replayed_pipeline_layouts;
+	replayed_shader_modules = impl.replayed_shader_modules;
+	replayed_render_passes = impl.replayed_render_passes;
+	replayed_compute_pipelines = impl.replayed_compute_pipelines;
+	replayed_graphics_pipelines = impl.replayed_graphics_pipelines;
 }
 
 void StateReplayer::Impl::parse(StateCreatorInterface &iface, DatabaseInterface *resolver, const void *buffer_, size_t total_size)

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -138,6 +138,11 @@ public:
 	// Setting to false can help improve replay performance in multi-threaded scenarios.
 	void set_resolve_derivative_pipeline_handles(bool enable);
 
+	// Default is true. If true, the replayer will make sure the shader module handle is a valid VkShaderModule.
+	// If false, VkShaderModule handles are filled with the object hash instead.
+	// It is up to the application to overwrite the correct VkShaderModule later.
+	void set_resolve_shader_module_handles(bool enable);
+
 	ScratchAllocator &get_allocator();
 
 	// Disable copies (and moves).

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -143,6 +143,9 @@ public:
 	// It is up to the application to overwrite the correct VkShaderModule later.
 	void set_resolve_shader_module_handles(bool enable);
 
+	// Lets other StateReplayers have the same references to objects.
+	void copy_handle_references(const StateReplayer &replayer);
+
 	ScratchAllocator &get_allocator();
 
 	// Disable copies (and moves).

--- a/fossilize_db.cpp
+++ b/fossilize_db.cpp
@@ -49,6 +49,27 @@ static_assert(FOSSILIZE_BLOB_HASH_LENGTH >= 32, "Blob hash length must be at lea
 
 namespace Fossilize
 {
+class ConditionalLockGuard
+{
+public:
+	ConditionalLockGuard(std::mutex &lock_, bool enable_)
+		: lock(lock_), enable(enable_)
+	{
+		if (enable)
+			lock.lock();
+	}
+
+	~ConditionalLockGuard()
+	{
+		if (enable)
+			lock.unlock();
+	}
+
+private:
+	std::mutex &lock;
+	bool enable;
+};
+
 struct DumbDirectoryDatabase : DatabaseInterface
 {
 	DumbDirectoryDatabase(const string &base, DatabaseMode mode_)
@@ -665,6 +686,7 @@ struct StreamArchive : DatabaseInterface
 			if ((flags & PAYLOAD_READ_RAW_FOSSILIZE_DB_BIT) != 0)
 			{
 				// Include the header.
+				ConditionalLockGuard holder(read_lock, (flags & PAYLOAD_READ_CONCURRENT_BIT) != 0);
 				if (fseek(file, itr->second.offset - sizeof(PayloadHeaderRaw), SEEK_SET) < 0)
 					return false;
 
@@ -674,7 +696,7 @@ struct StreamArchive : DatabaseInterface
 			}
 			else
 			{
-				if (!decode_payload(blob, out_size, itr->second))
+				if (!decode_payload(blob, out_size, itr->second, (flags & PAYLOAD_READ_CONCURRENT_BIT) != 0))
 					return false;
 			}
 		}
@@ -850,17 +872,20 @@ struct StreamArchive : DatabaseInterface
 		PayloadHeader header;
 	};
 
-	bool decode_payload_uncompressed(void *blob, size_t blob_size, const Entry &entry)
+	bool decode_payload_uncompressed(void *blob, size_t blob_size, const Entry &entry, bool concurrent)
 	{
 		if (entry.header.uncompressed_size != blob_size || entry.header.payload_size != blob_size)
 			return false;
 
-		if (fseek(file, entry.offset, SEEK_SET) < 0)
-			return false;
+		{
+			ConditionalLockGuard holder(read_lock, concurrent);
+			if (fseek(file, entry.offset, SEEK_SET) < 0)
+				return false;
 
-		size_t read_size = entry.header.payload_size;
-		if (fread(blob, 1, read_size, file) != read_size)
-			return false;
+			size_t read_size = entry.header.payload_size;
+			if (fread(blob, 1, read_size, file) != read_size)
+				return false;
+		}
 
 		if (entry.header.crc != 0) // Verify checksum.
 		{
@@ -875,34 +900,37 @@ struct StreamArchive : DatabaseInterface
 		return true;
 	}
 
-	bool decode_payload_deflate(void *blob, size_t blob_size, const Entry &entry)
+	bool decode_payload_deflate(void *blob, size_t blob_size, const Entry &entry, bool concurrent)
 	{
 		if (entry.header.uncompressed_size != blob_size)
 			return false;
 
-		if (zlib_buffer_size < entry.header.payload_size)
 		{
-			auto *new_zlib_buffer = static_cast<uint8_t *>(realloc(zlib_buffer, entry.header.payload_size));
-			if (new_zlib_buffer)
+			ConditionalLockGuard holder(read_lock, concurrent);
+			if (zlib_buffer_size < entry.header.payload_size)
 			{
-				zlib_buffer = new_zlib_buffer;
-				zlib_buffer_size = entry.header.payload_size;
+				auto *new_zlib_buffer = static_cast<uint8_t *>(realloc(zlib_buffer, entry.header.payload_size));
+				if (new_zlib_buffer)
+				{
+					zlib_buffer = new_zlib_buffer;
+					zlib_buffer_size = entry.header.payload_size;
+				}
+				else
+				{
+					free(zlib_buffer);
+					zlib_buffer = nullptr;
+					zlib_buffer_size = 0;
+				}
 			}
-			else
-			{
-				free(zlib_buffer);
-				zlib_buffer = nullptr;
-				zlib_buffer_size = 0;
-			}
+
+			if (!zlib_buffer)
+				return false;
+
+			if (fseek(file, entry.offset, SEEK_SET) < 0)
+				return false;
+			if (fread(zlib_buffer, 1, entry.header.payload_size, file) != entry.header.payload_size)
+				return false;
 		}
-
-		if (!zlib_buffer)
-			return false;
-
-		if (fseek(file, entry.offset, SEEK_SET) < 0)
-			return false;
-		if (fread(zlib_buffer, 1, entry.header.payload_size, file) != entry.header.payload_size)
-			return false;
 
 		if (entry.header.crc != 0) // Verify checksum.
 		{
@@ -923,12 +951,12 @@ struct StreamArchive : DatabaseInterface
 		return true;
 	}
 
-	bool decode_payload(void *blob, size_t blob_size, const Entry &entry)
+	bool decode_payload(void *blob, size_t blob_size, const Entry &entry, bool concurrent)
 	{
 		if (entry.header.format == FOSSILIZE_COMPRESSION_NONE)
-			return decode_payload_uncompressed(blob, blob_size, entry);
+			return decode_payload_uncompressed(blob, blob_size, entry, concurrent);
 		else if (entry.header.format == FOSSILIZE_COMPRESSION_DEFLATE)
-			return decode_payload_deflate(blob, blob_size, entry);
+			return decode_payload_deflate(blob, blob_size, entry, concurrent);
 		else
 			return false;
 	}
@@ -940,6 +968,7 @@ struct StreamArchive : DatabaseInterface
 	uint8_t *zlib_buffer = nullptr;
 	size_t zlib_buffer_size = 0;
 	bool alive = false;
+	std::mutex read_lock;
 };
 
 DatabaseInterface *create_stream_archive_database(const char *path, DatabaseMode mode)

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -71,6 +71,12 @@ enum PayloadReadFlagBits
 	// The only use for this flag is to transparently transfer payloads to other stream archive databases.
 	PAYLOAD_READ_RAW_FOSSILIZE_DB_BIT = 1 << 0,
 
+	// Allows read_entry to be called concurrently from multiple threads.
+	// Might cause locking when reading from database depending on implementation.
+	// Decompression if needed is always lock-free.
+	// *NOTE*: Only tested with the Fossilize database format.
+	PAYLOAD_READ_CONCURRENT_BIT = 1 << 1,
+
 	PAYLOAD_READ_MAX_ENUM = 0x7fffffff
 };
 using PayloadWriteFlags = uint32_t;

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -94,6 +94,7 @@ public:
 
 	struct TypeProgress
 	{
+		uint32_t parsed;
 		uint32_t completed;
 		uint32_t skipped;
 		uint32_t total;

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -104,6 +104,7 @@ public:
 		TypeProgress compute;
 		TypeProgress graphics;
 
+		uint32_t completed_modules;
 		uint32_t total_modules;
 		uint32_t banned_modules;
 

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -54,6 +54,7 @@ public:
 		// (Linux only) Inherits the process group used by caller. Lets all child processes for replayer
 		// belong to caller. Useful for CLI tools which use this interface.
 		// If this is used, ExternalReplayer::kill() won't work since it relies on process groups to work.
+		// (Windows only) If true, a JobObject is created to make sure that if the calling process is killed, so are the Fossilize replayer processes.
 		bool inherit_process_group;
 	};
 

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -50,6 +50,11 @@ public:
 
 		// Redirect stdout and stderr to /dev/null or NUL.
 		bool quiet;
+
+		// (Linux only) Inherits the process group used by caller. Lets all child processes for replayer
+		// belong to caller. Useful for CLI tools which use this interface.
+		// If this is used, ExternalReplayer::kill() won't work since it relies on process groups to work.
+		bool inherit_process_group;
 	};
 
 	ExternalReplayer();

--- a/fossilize_external_replayer_control_block.hpp
+++ b/fossilize_external_replayer_control_block.hpp
@@ -57,6 +57,8 @@ struct SharedControlBlock
 	std::atomic<uint32_t> skipped_compute;
 	std::atomic<uint32_t> clean_process_deaths;
 	std::atomic<uint32_t> dirty_process_deaths;
+	std::atomic<uint32_t> parsed_graphics;
+	std::atomic<uint32_t> parsed_compute;
 	std::atomic<uint32_t> total_graphics;
 	std::atomic<uint32_t> total_compute;
 	std::atomic<uint32_t> total_modules;

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -270,8 +270,7 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		return false;
 	}
 
-	// vfork blocks until the child has called exec().
-	pid_t new_pid = vfork();
+	pid_t new_pid = fork();
 	if (new_pid > 0)
 	{
 		close(fd);

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -96,9 +96,11 @@ ExternalReplayer::PollResult ExternalReplayer::Impl::poll_progress(ExternalRepla
 		return ExternalReplayer::PollResult::ResultNotReady;
 
 	progress.compute.total = shm_block->total_compute.load(std::memory_order_relaxed);
+	progress.compute.parsed = shm_block->parsed_compute.load(std::memory_order_relaxed);
 	progress.compute.skipped = shm_block->skipped_compute.load(std::memory_order_relaxed);
 	progress.compute.completed = shm_block->successful_compute.load(std::memory_order_relaxed);
 	progress.graphics.total = shm_block->total_graphics.load(std::memory_order_relaxed);
+	progress.graphics.parsed = shm_block->parsed_graphics.load(std::memory_order_relaxed);
 	progress.graphics.skipped = shm_block->skipped_graphics.load(std::memory_order_relaxed);
 	progress.graphics.completed = shm_block->successful_graphics.load(std::memory_order_relaxed);
 	progress.completed_modules = shm_block->successful_modules.load(std::memory_order_relaxed);

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -279,11 +279,14 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	}
 	else if (new_pid == 0)
 	{
-		// Set the process group ID so we can kill all the child processes as needed.
-		if (setpgid(0, 0) < 0)
+		if (!options.inherit_process_group)
 		{
-			LOGE("Failed to set PGID in child.\n");
-			exit(1);
+			// Set the process group ID so we can kill all the child processes as needed.
+			if (setpgid(0, 0) < 0)
+			{
+				LOGE("Failed to set PGID in child.\n");
+				exit(1);
+			}
 		}
 
 		char fd_name[16];

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -101,6 +101,7 @@ ExternalReplayer::PollResult ExternalReplayer::Impl::poll_progress(ExternalRepla
 	progress.graphics.total = shm_block->total_graphics.load(std::memory_order_relaxed);
 	progress.graphics.skipped = shm_block->skipped_graphics.load(std::memory_order_relaxed);
 	progress.graphics.completed = shm_block->successful_graphics.load(std::memory_order_relaxed);
+	progress.completed_modules = shm_block->successful_modules.load(std::memory_order_relaxed);
 	progress.total_modules = shm_block->total_modules.load(std::memory_order_relaxed);
 	progress.banned_modules = shm_block->banned_modules.load(std::memory_order_relaxed);
 	progress.clean_crashes = shm_block->clean_process_deaths.load(std::memory_order_relaxed);

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -86,9 +86,11 @@ ExternalReplayer::PollResult ExternalReplayer::Impl::poll_progress(ExternalRepla
 		return ExternalReplayer::PollResult::ResultNotReady;
 
 	progress.compute.total = shm_block->total_compute.load(std::memory_order_relaxed);
+	progress.compute.parsed = shm_block->parsed_compute.load(std::memory_order_relaxed);
 	progress.compute.skipped = shm_block->skipped_compute.load(std::memory_order_relaxed);
 	progress.compute.completed = shm_block->successful_compute.load(std::memory_order_relaxed);
 	progress.graphics.total = shm_block->total_graphics.load(std::memory_order_relaxed);
+	progress.graphics.parsed = shm_block->parsed_graphics.load(std::memory_order_relaxed);
 	progress.graphics.skipped = shm_block->skipped_graphics.load(std::memory_order_relaxed);
 	progress.graphics.completed = shm_block->successful_graphics.load(std::memory_order_relaxed);
 	progress.completed_modules = shm_block->successful_modules.load(std::memory_order_relaxed);

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -91,6 +91,7 @@ ExternalReplayer::PollResult ExternalReplayer::Impl::poll_progress(ExternalRepla
 	progress.graphics.total = shm_block->total_graphics.load(std::memory_order_relaxed);
 	progress.graphics.skipped = shm_block->skipped_graphics.load(std::memory_order_relaxed);
 	progress.graphics.completed = shm_block->successful_graphics.load(std::memory_order_relaxed);
+	progress.completed_modules = shm_block->successful_modules.load(std::memory_order_relaxed);
 	progress.total_modules = shm_block->total_modules.load(std::memory_order_relaxed);
 	progress.banned_modules = shm_block->banned_modules.load(std::memory_order_relaxed);
 	progress.clean_crashes = shm_block->clean_process_deaths.load(std::memory_order_relaxed);

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -42,6 +42,7 @@ struct ExternalReplayer::Impl
 	HANDLE process = nullptr;
 	HANDLE mapping_handle = nullptr;
 	HANDLE mutex = nullptr;
+	HANDLE job_handle = nullptr;
 	SharedControlBlock *shm_block = nullptr;
 	size_t shm_block_size = 0;
 	DWORD exit_code = 0;
@@ -68,6 +69,8 @@ ExternalReplayer::Impl::~Impl()
 		CloseHandle(mutex);
 	if (process)
 		CloseHandle(process);
+	if (job_handle)
+		CloseHandle(job_handle);
 }
 
 uintptr_t ExternalReplayer::Impl::get_process_handle() const
@@ -163,6 +166,11 @@ int ExternalReplayer::Impl::wait()
 	GetExitCodeProcess(process, &exit_code);
 	CloseHandle(process);
 	process = nullptr;
+	if (job_handle)
+	{
+		CloseHandle(job_handle);
+		job_handle = nullptr;
+	}
 	return exit_code;
 }
 
@@ -305,16 +313,46 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
 	}
 
+	if (options.inherit_process_group)
+	{
+		job_handle = CreateJobObjectA(nullptr, nullptr);
+		if (!job_handle)
+		{
+			LOGE("Failed to create job handle.\n");
+			// Not fatal, we just won't bother with this.
+		}
+		else
+		{
+			// Kill all child processes if the parent dies.
+			JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = {};
+			jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+			if (!SetInformationJobObject(job_handle, JobObjectExtendedLimitInformation, &jeli, sizeof(jeli)))
+			{
+				LOGE("Failed to set information for job object.\n");
+				// Again, not fatal.
+			}
+		}
+	}
+
 	// For whatever reason, this string must be mutable. Dupe it.
 	char *duped_string = _strdup(cmdline.c_str());
 	PROCESS_INFORMATION pi = {};
-	if (!CreateProcessA(nullptr, duped_string, nullptr, nullptr, TRUE, CREATE_NO_WINDOW, nullptr, nullptr,
+	if (!CreateProcessA(nullptr, duped_string, nullptr, nullptr, TRUE, CREATE_NO_WINDOW | CREATE_SUSPENDED, nullptr, nullptr,
 	                    &si, &pi))
 	{
 		LOGE("Failed to create child process.\n");
 		free(duped_string);
 		return false;
 	}
+
+	if (job_handle && !AssignProcessToJobObject(job_handle, pi.hProcess))
+	{
+		LOGE("Failed to assign process to job handle.\n");
+		// This isn't really fatal, just continue on.
+	}
+
+	// Now we can resume the main thread, after we've added the process to our job object.
+	ResumeThread(pi.hThread);
 
 	free(duped_string);
 	if (nul != INVALID_HANDLE_VALUE)


### PR DESCRIPTION
This is a rewrite of how the replayer replays data sets.
There are a few new stages here:

- Create all trivial objects, i.e. render passes, pipeline layouts, etc in main thread.
- Decompress and parse all pipelines in parallel, do not resolve shader module hashes here.
- Figure out all shader module hashes which are actually in use.
- Decompress, parse and create all shader modules in parallel.
- Resolve VkShaderModule references to the real VkShaderModule.
- Queue up all pipelines for parallel creation.

For data sets where we have warmed up on-disk caches, this turns a single-threaded application (all CPU time is spent parsing and decompressing) into a fully threaded one.

This strategy exposes a major design flaw with the robust replayer. Due to current limitations, the robust replayer can only have single-threaded processes, but this will need to change. There is little to no performance improvement with robust replayer as it stands, that will come later.

I also changed the robust replayer reporting scheme. Now it will not look so idle while doing the initial decompression and parsing steps and the API has extra fields which lets us keep track of parsing and decompression.

```
Fossilize INFO: =================
Fossilize INFO:  Progress report:
Fossilize INFO:    Parsed graphics 22571 / 22571
Fossilize INFO:    Parsed compute 38 / 38
Fossilize INFO:    Decompress modules 1524 / 17369, skipped 0
Fossilize INFO:    Compile graphics 0 / 22571, skipped 0
Fossilize INFO:    Compile compute 0 / 38, skipped 0
Fossilize INFO:    Clean crashes 0
Fossilize INFO:    Dirty crashes 0
Fossilize INFO: =================
```
The results might look at a bit weird with --num-threads > 1, but that's known and expected due to redundant parsing and redundant compilation of parent pipelines (in a derived pipeline hierarchy). That multi-process path will need to be removed later anyways.

Also, fix an issue on CLI where using --progress would let child processes linger on even when the main process was killed with ^C.