### PR TITLE
Greatly improve performance when replaying robustly

### DIFF
--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -963,7 +963,7 @@ struct ThreadedReplayer : StateCreatorInterface
 				if (!outside_range_hashes.count(h))
 				{
 					PipelineWorkItem work_item;
-					work_item.index = d.index;
+					work_item.index = ~0u;
 					work_item.hash = d.hash;
 					work_item.parse_only = true;
 					work_item.tag = DerivedInfo::get_tag();


### PR DESCRIPTION
Rather than parse all pipelines up front, parse lazily only the range of pipelines desired. Parent pipelines are parsed as necessary. This greatly speeds up robust replay speed.

This is not the perfect solution, but it is close enough I think for now. Performance is within 2x of a "pure" non-robust replay on my test systems.

Also, make progress reporting a little more accurate.