### PR TITLE
Split out type definitions to their own header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 add_library(fossilize STATIC
         fossilize.hpp fossilize.cpp
         fossilize_exception.hpp
+        fossilize_types.hpp
         varint.cpp varint.hpp
         fossilize_db.cpp fossilize_db.hpp
         path.hpp path.cpp)

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -23,35 +23,12 @@
 #pragma once
 
 #include "vulkan.h"
-#include <stdint.h>
 #include <stddef.h>
+#include "fossilize_types.hpp"
 
 namespace Fossilize
 {
-enum ResourceTag
-{
-	RESOURCE_APPLICATION_INFO = 0,
-	RESOURCE_SAMPLER = 1,
-	RESOURCE_DESCRIPTOR_SET_LAYOUT = 2,
-	RESOURCE_PIPELINE_LAYOUT = 3,
-	RESOURCE_SHADER_MODULE = 4,
-	RESOURCE_RENDER_PASS = 5,
-	RESOURCE_GRAPHICS_PIPELINE = 6,
-	RESOURCE_COMPUTE_PIPELINE = 7,
-	RESOURCE_APPLICATION_BLOB_LINK = 8,
-	RESOURCE_COUNT = 9
-};
-
-enum
-{
-	FOSSILIZE_FORMAT_VERSION = 6,
-	FOSSILIZE_FORMAT_MIN_COMPAT_VERSION = 5
-};
-
 class DatabaseInterface;
-
-using Hash = uint64_t;
-
 class Hasher;
 
 class ScratchAllocator

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#include <stdint.h>
-#include "fossilize.hpp"
+#include "fossilize_types.hpp"
+#include <stddef.h>
 
 namespace Fossilize
 {

--- a/fossilize_types.hpp
+++ b/fossilize_types.hpp
@@ -1,0 +1,50 @@
+/* Copyright (c) 2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+namespace Fossilize
+{
+enum ResourceTag
+{
+	RESOURCE_APPLICATION_INFO = 0,
+	RESOURCE_SAMPLER = 1,
+	RESOURCE_DESCRIPTOR_SET_LAYOUT = 2,
+	RESOURCE_PIPELINE_LAYOUT = 3,
+	RESOURCE_SHADER_MODULE = 4,
+	RESOURCE_RENDER_PASS = 5,
+	RESOURCE_GRAPHICS_PIPELINE = 6,
+	RESOURCE_COMPUTE_PIPELINE = 7,
+	RESOURCE_APPLICATION_BLOB_LINK = 8,
+	RESOURCE_COUNT = 9
+};
+
+enum
+{
+	FOSSILIZE_FORMAT_VERSION = 6,
+	FOSSILIZE_FORMAT_MIN_COMPAT_VERSION = 5
+};
+
+using Hash = uint64_t;
+}


### PR DESCRIPTION
Avoids having to include vulkan.h in external replayer.