### PR TITLE
Add support for application info filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      compiler: gcc
-      env:
-        - GENERATOR="Unix Makefiles"
-    - os: linux
-      dist: trusty
       compiler: clang
       env:
         - GENERATOR="Unix Makefiles"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 add_library(fossilize STATIC
         fossilize.hpp fossilize.cpp
         fossilize_exception.hpp
+        fossilize_application_filter.hpp fossilize_application_filter.cpp
         fossilize_types.hpp
         varint.cpp varint.hpp
         fossilize_db.cpp fossilize_db.hpp

--- a/fossilize.cpp
+++ b/fossilize.cpp
@@ -3358,10 +3358,10 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 							                            payload_flags);
 							need_flush = true;
 						}
-
-						// Don't need to keep copied data around, reset the allocator.
-						allocator.reset();
 					}
+
+					// Don't need to keep copied data around, reset the allocator.
+					allocator.reset();
 				}
 				else
 				{
@@ -3397,10 +3397,10 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 							                            payload_flags);
 							need_flush = true;
 						}
-
-						// Don't need to keep copied data around, reset the allocator.
-						allocator.reset();
 					}
+
+					// Don't need to keep copied data around, reset the allocator.
+					allocator.reset();
 				}
 				else
 				{
@@ -3436,10 +3436,10 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 							                            payload_flags);
 							need_flush = true;
 						}
-
-						// Don't need to keep copied data around, reset the allocator.
-						allocator.reset();
 					}
+
+					// Don't need to keep copied data around, reset the allocator.
+					allocator.reset();
 				}
 				else
 				{
@@ -3475,10 +3475,10 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 							                            payload_flags);
 							need_flush = true;
 						}
-
-						// Don't need to keep copied data around, reset the allocator.
-						allocator.reset();
 					}
+
+					// Don't need to keep copied data around, reset the allocator.
+					allocator.reset();
 				}
 				else
 				{

--- a/fossilize.cpp
+++ b/fossilize.cpp
@@ -19,6 +19,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
@@ -35,12 +36,14 @@
 #include "fossilize_db.hpp"
 #include "layer/utils.hpp"
 #include "fossilize_exception.hpp"
+#include "fossilize_application_filter.hpp"
 
 #define RAPIDJSON_HAS_STDSTRING 1
 #include "rapidjson/document.h"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/writer.h"
 using namespace rapidjson;
+
 
 #ifdef PRETTY_WRITER
 using CustomWriter = PrettyWriter<StringBuffer>;
@@ -225,6 +228,7 @@ struct StateRecorder::Impl
 	ScratchAllocator allocator;
 	ScratchAllocator temp_allocator;
 	DatabaseInterface *database_iface = nullptr;
+	ApplicationInfoFilter *application_info_filter = nullptr;
 
 	std::unordered_map<Hash, VkDescriptorSetLayoutCreateInfo *> descriptor_sets;
 	std::unordered_map<Hash, VkPipelineLayoutCreateInfo *> pipeline_layouts;
@@ -2534,6 +2538,11 @@ void StateRecorder::record_physical_device_features(const VkPhysicalDeviceFeatur
 	impl->application_feature_hash.physical_device_features_hash = Hashing::compute_hash_physical_device_features(*impl->physical_device_features);
 }
 
+void StateRecorder::set_application_info_filter(ApplicationInfoFilter *filter)
+{
+	impl->application_info_filter = filter;
+}
+
 const StateRecorderApplicationFeatureHash &StateRecorder::get_application_feature_hash() const
 {
 	return impl->application_feature_hash;
@@ -3129,6 +3138,8 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 	if (checksum)
 		payload_flags |= PAYLOAD_WRITE_COMPUTE_CHECKSUM_BIT;
 
+	bool write_database_entries = true;
+
 	// Start by preparing in the thread since we need to parse an archive potentially, and that might block a little bit.
 	if (database_iface)
 	{
@@ -3138,13 +3149,17 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 			LOGE("Failed to prepare database, will not dump data to database.\n");
 			database_iface = nullptr;
 		}
+
+		// Check here in the worker thread if we should write database entries for this application info.
+		if (application_info_filter)
+			write_database_entries = application_info_filter->test_application_info(application_info);
 	}
 
 	// Keep a single, pre-allocated buffer.
 	vector<uint8_t> blob;
 	blob.reserve(64 * 1024);
 
-	if (database_iface)
+	if (database_iface && write_database_entries)
 	{
 		assert(looping);
 		Hasher h;
@@ -3219,14 +3234,18 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_SAMPLER, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_SAMPLER, hash))
+					if (write_database_entries)
 					{
-						serialize_sampler(hash, *create_info, blob);
-						database_iface->write_entry(RESOURCE_SAMPLER, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
+						if (register_application_link_hash(RESOURCE_SAMPLER, hash, blob))
+							need_flush = true;
+
+						if (!database_iface->has_entry(RESOURCE_SAMPLER, hash))
+						{
+							serialize_sampler(hash, *create_info, blob);
+							database_iface->write_entry(RESOURCE_SAMPLER, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+						}
 					}
 				}
 				else
@@ -3251,14 +3270,18 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_RENDER_PASS, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_RENDER_PASS, hash))
+					if (write_database_entries)
 					{
-						serialize_render_pass(hash, *create_info, blob);
-						database_iface->write_entry(RESOURCE_RENDER_PASS, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
+						if (register_application_link_hash(RESOURCE_RENDER_PASS, hash, blob))
+							need_flush = true;
+
+						if (!database_iface->has_entry(RESOURCE_RENDER_PASS, hash))
+						{
+							serialize_render_pass(hash, *create_info, blob);
+							database_iface->write_entry(RESOURCE_RENDER_PASS, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+						}
 					}
 				}
 				else
@@ -3283,15 +3306,19 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_SHADER_MODULE, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_SHADER_MODULE, hash))
+					if (write_database_entries)
 					{
-						serialize_shader_module(hash, *create_info, blob, allocator);
-						database_iface->write_entry(RESOURCE_SHADER_MODULE, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
-						allocator.reset();
+						if (register_application_link_hash(RESOURCE_SHADER_MODULE, hash, blob))
+							need_flush = true;
+
+						if (!database_iface->has_entry(RESOURCE_SHADER_MODULE, hash))
+						{
+							serialize_shader_module(hash, *create_info, blob, allocator);
+							database_iface->write_entry(RESOURCE_SHADER_MODULE, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+							allocator.reset();
+						}
 					}
 				}
 				else
@@ -3319,18 +3346,22 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_DESCRIPTOR_SET_LAYOUT, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_DESCRIPTOR_SET_LAYOUT, hash))
+					if (write_database_entries)
 					{
-						serialize_descriptor_set_layout(hash, *create_info_copy, blob);
-						database_iface->write_entry(RESOURCE_DESCRIPTOR_SET_LAYOUT, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
-					}
+						if (register_application_link_hash(RESOURCE_DESCRIPTOR_SET_LAYOUT, hash, blob))
+							need_flush = true;
 
-					// Don't need to keep copied data around, reset the allocator.
-					allocator.reset();
+						if (!database_iface->has_entry(RESOURCE_DESCRIPTOR_SET_LAYOUT, hash))
+						{
+							serialize_descriptor_set_layout(hash, *create_info_copy, blob);
+							database_iface->write_entry(RESOURCE_DESCRIPTOR_SET_LAYOUT, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+						}
+
+						// Don't need to keep copied data around, reset the allocator.
+						allocator.reset();
+					}
 				}
 				else
 				{
@@ -3354,18 +3385,22 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_PIPELINE_LAYOUT, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_PIPELINE_LAYOUT, hash))
+					if (write_database_entries)
 					{
-						serialize_pipeline_layout(hash, *create_info_copy, blob);
-						database_iface->write_entry(RESOURCE_PIPELINE_LAYOUT, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
-					}
+						if (register_application_link_hash(RESOURCE_PIPELINE_LAYOUT, hash, blob))
+							need_flush = true;
 
-					// Don't need to keep copied data around, reset the allocator.
-					allocator.reset();
+						if (!database_iface->has_entry(RESOURCE_PIPELINE_LAYOUT, hash))
+						{
+							serialize_pipeline_layout(hash, *create_info_copy, blob);
+							database_iface->write_entry(RESOURCE_PIPELINE_LAYOUT, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+						}
+
+						// Don't need to keep copied data around, reset the allocator.
+						allocator.reset();
+					}
 				}
 				else
 				{
@@ -3389,18 +3424,22 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_GRAPHICS_PIPELINE, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_GRAPHICS_PIPELINE, hash))
+					if (write_database_entries)
 					{
-						serialize_graphics_pipeline(hash, *create_info_copy, blob);
-						database_iface->write_entry(RESOURCE_GRAPHICS_PIPELINE, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
-					}
+						if (register_application_link_hash(RESOURCE_GRAPHICS_PIPELINE, hash, blob))
+							need_flush = true;
 
-					// Don't need to keep copied data around, reset the allocator.
-					allocator.reset();
+						if (!database_iface->has_entry(RESOURCE_GRAPHICS_PIPELINE, hash))
+						{
+							serialize_graphics_pipeline(hash, *create_info_copy, blob);
+							database_iface->write_entry(RESOURCE_GRAPHICS_PIPELINE, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+						}
+
+						// Don't need to keep copied data around, reset the allocator.
+						allocator.reset();
+					}
 				}
 				else
 				{
@@ -3424,18 +3463,22 @@ void StateRecorder::Impl::record_task(StateRecorder *recorder, bool looping)
 
 				if (database_iface)
 				{
-					if (register_application_link_hash(RESOURCE_COMPUTE_PIPELINE, hash, blob))
-						need_flush = true;
-
-					if (!database_iface->has_entry(RESOURCE_COMPUTE_PIPELINE, hash))
+					if (write_database_entries)
 					{
-						serialize_compute_pipeline(hash, *create_info_copy, blob);
-						database_iface->write_entry(RESOURCE_COMPUTE_PIPELINE, hash, blob.data(), blob.size(), payload_flags);
-						need_flush = true;
-					}
+						if (register_application_link_hash(RESOURCE_COMPUTE_PIPELINE, hash, blob))
+							need_flush = true;
 
-					// Don't need to keep copied data around, reset the allocator.
-					allocator.reset();
+						if (!database_iface->has_entry(RESOURCE_COMPUTE_PIPELINE, hash))
+						{
+							serialize_compute_pipeline(hash, *create_info_copy, blob);
+							database_iface->write_entry(RESOURCE_COMPUTE_PIPELINE, hash, blob.data(), blob.size(),
+							                            payload_flags);
+							need_flush = true;
+						}
+
+						// Don't need to keep copied data around, reset the allocator.
+						allocator.reset();
+					}
 				}
 				else
 				{

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -30,6 +30,7 @@ namespace Fossilize
 {
 class DatabaseInterface;
 class Hasher;
+class ApplicationInfoFilter;
 
 class ScratchAllocator
 {
@@ -186,6 +187,7 @@ public:
 	// This can be relevant when using more exotic features.
 	void record_physical_device_features(const VkPhysicalDeviceFeatures2 &device_features);
 	void record_physical_device_features(const VkPhysicalDeviceFeatures &device_features);
+	void set_application_info_filter(ApplicationInfoFilter *filter);
 
 	const StateRecorderApplicationFeatureHash &get_application_feature_hash() const;
 

--- a/fossilize_application_filter.cpp
+++ b/fossilize_application_filter.cpp
@@ -1,0 +1,324 @@
+/* Copyright (c) 2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fossilize_application_filter.hpp"
+#include "layer/utils.hpp"
+#include "vulkan.h"
+#include <mutex>
+#include <condition_variable>
+#include <future>
+#include <vector>
+#include <stdexcept>
+#include <unordered_set>
+#include <unordered_map>
+#include <stdio.h>
+
+#define RAPIDJSON_HAS_STDSTRING 1
+#include "rapidjson/document.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/writer.h"
+using namespace rapidjson;
+
+namespace Fossilize
+{
+enum { FOSSILIZE_APPLICATION_INFO_FILTER_VERSION = 1 };
+
+struct AppInfo
+{
+	uint32_t minimum_api_version = VK_MAKE_VERSION(1, 0, 0);
+	uint32_t minimum_application_version = 0;
+	uint32_t minimum_engine_version = 0;
+};
+
+struct ApplicationInfoFilter::Impl
+{
+	std::unordered_set<std::string> blacklisted_application_names;
+	std::unordered_set<std::string> blacklisted_engine_names;
+	std::unordered_map<std::string, AppInfo> application_infos;
+	std::unordered_map<std::string, AppInfo> engine_infos;
+
+	bool parsing_done = false;
+	bool parsing_success = false;
+	std::future<void> task;
+
+	void parse_async(const char *path);
+	bool test_application_info(const VkApplicationInfo *info);
+	bool parse(const std::string &path);
+};
+
+bool ApplicationInfoFilter::Impl::test_application_info(const VkApplicationInfo *info)
+{
+	// No app info, just assume true.
+	if (!info)
+		return true;
+
+	if (task.valid())
+		task.wait();
+
+	if (!parsing_success)
+	{
+		LOGE("Failed to parse ApplicationInfoFilter, letting recording go through.\n");
+		return true;
+	}
+
+	// First, check for blacklists.
+	if (info->pApplicationName && blacklisted_application_names.count(info->pApplicationName))
+	{
+		LOGI("pApplicationName %s is blacklisted for recording. Skipping.\n", info->pApplicationName);
+		return false;
+	}
+
+	if (info->pEngineName && blacklisted_engine_names.count(info->pEngineName))
+	{
+		LOGI("pEngineName %s is blacklisted for recording. Skipping.\n", info->pEngineName);
+		return false;
+	}
+
+	// Check versioning for applicationName.
+	if (info->pApplicationName)
+	{
+		auto itr = application_infos.find(info->pApplicationName);
+		if (itr != end(application_infos))
+		{
+			if (info->applicationVersion < itr->second.minimum_application_version)
+			{
+				LOGI("applicationVersion %u is too low for pApplicationName %s. Skipping.\n",
+				     info->applicationVersion, info->pApplicationName);
+				return false;
+			}
+
+			if (info->apiVersion < itr->second.minimum_api_version)
+			{
+				LOGI("apiVersion %u is too low for pApplicationName %s. Skipping.\n",
+				     info->apiVersion, info->pApplicationName);
+				return false;
+			}
+		}
+	}
+
+	// Check versioning for engineName.
+	if (info->pEngineName)
+	{
+		auto itr = engine_infos.find(info->pEngineName);
+		if (itr != end(application_infos))
+		{
+			if (info->engineVersion < itr->second.minimum_engine_version)
+			{
+				LOGI("engineVersion %u is too low for pApplicationName %s. Skipping.\n",
+				     info->engineVersion, info->pApplicationName);
+				return false;
+			}
+
+			if (info->apiVersion < itr->second.minimum_api_version)
+			{
+				LOGI("apiVersion %u is too low for pApplicationName %s. Skipping.\n",
+				     info->apiVersion, info->pApplicationName);
+				return false;
+			}
+		}
+	}
+
+	// We didn't fail any filter, so we should record.
+	return true;
+}
+
+static std::vector<char> read_file(const char *path)
+{
+	FILE *file = fopen(path, "rb");
+	if (!file)
+		return {};
+
+	fseek(file, 0, SEEK_END);
+	long len = ftell(file);
+
+	if (len < 0)
+	{
+		fclose(file);
+		return {};
+	}
+
+	rewind(file);
+	std::vector<char> buffer(len);
+	if (fread(buffer.data(), 1, len, file) != size_t(len))
+	{
+		fclose(file);
+		return {};
+	}
+
+	fclose(file);
+	return buffer;
+}
+
+static const Value &get_safe_member(const Value &value, const char *member)
+{
+	auto memb = value.FindMember(member);
+	if (memb == value.MemberEnd())
+		throw std::logic_error("Member not found.");
+	return memb->value;
+}
+
+static const Value *maybe_get_member(const Value &value, const char *member)
+{
+	auto memb = value.FindMember(member);
+	if (memb == value.MemberEnd())
+		return nullptr;
+	else
+		return &memb->value;
+}
+
+static std::string get_safe_member_string(const Value &value, const char *member)
+{
+	auto &memb = get_safe_member(value, member);
+	if (memb.IsString())
+	{
+		const char *str = memb.GetString();
+		return std::string(str, str + memb.GetStringLength());
+	}
+	else
+		throw std::logic_error("Not a string.");
+}
+
+static int get_safe_member_int(const Value &value, const char *member)
+{
+	auto &memb = get_safe_member(value, member);
+	if (memb.IsInt())
+		return memb.GetInt();
+	else
+		throw std::logic_error("Not an int.");
+}
+
+static unsigned default_get_member_uint(const Value &value, const char *member, unsigned default_value = 0)
+{
+	auto *memb = maybe_get_member(value, member);
+	if (!memb)
+		return default_value;
+	if (!memb->IsUint())
+		throw std::logic_error("Object is not uint.");
+	return memb->GetUint();
+}
+
+static void add_blacklists(std::unordered_set<std::string> &output, const Value *blacklist)
+{
+	if (!blacklist->IsObject())
+		throw std::logic_error("Not an object.");
+
+	for (auto itr = blacklist->MemberBegin(); itr != blacklist->MemberEnd(); ++itr)
+	{
+		if (!itr->value.IsString())
+			throw std::logic_error("Not a string.");
+
+		const char *str = itr->value.GetString();
+		output.insert(std::string(str, str + itr->value.GetStringLength()));
+	}
+}
+
+static void add_application_filters(std::unordered_map<std::string, AppInfo> &output, const Value *filters)
+{
+	if (!filters->IsObject())
+		throw std::logic_error("Not an object.");
+
+	for (auto itr = filters->MemberBegin(); itr != filters->MemberEnd(); ++itr)
+	{
+		if (!itr->value.IsObject())
+			throw std::logic_error("Not an object.");
+
+		AppInfo info;
+
+		auto &value = itr->value;
+		info.minimum_api_version = default_get_member_uint(value, "minimumApiVersion");
+		info.minimum_engine_version = default_get_member_uint(value, "minimumEngineVersion");
+		info.minimum_application_version = default_get_member_uint(value, "minimumApplicationVersion");
+		output[itr->name.GetString()] = info;
+	}
+}
+
+bool ApplicationInfoFilter::Impl::parse(const std::string &path)
+{
+	auto buffer = read_file(path.c_str());
+
+	Document doc;
+	doc.Parse(buffer.data(), buffer.size());
+	if (doc.HasParseError())
+		return false;
+
+	if (get_safe_member_string(doc, "asset") != "FossilizeApplicationInfoFilter")
+		return false;
+	if (get_safe_member_int(doc, "version") != FOSSILIZE_APPLICATION_INFO_FILTER_VERSION)
+		return false;
+
+	auto *blacklist = maybe_get_member(doc, "blacklistedApplicationNames");
+	if (blacklist)
+		add_blacklists(blacklisted_application_names, blacklist);
+	blacklist = maybe_get_member(doc, "blacklistedEngineNames");
+	if (blacklist)
+		add_blacklists(blacklisted_engine_names, blacklist);
+
+	auto *filters = maybe_get_member(doc, "applicationFilters");
+	if (filters)
+		add_application_filters(application_infos, filters);
+	filters = maybe_get_member(doc, "engineFilters");
+	if (filters)
+		add_application_filters(engine_infos, filters);
+
+	return true;
+}
+
+void ApplicationInfoFilter::Impl::parse_async(const char *path_)
+{
+	std::string path = path_;
+	task = std::async(std::launch::async, [this, path]() {
+		bool ret;
+		try
+		{
+			ret = parse(path);
+		}
+		catch (const std::exception &e)
+		{
+			LOGE("Caught exception in ApplicationInfoFilter::Impl::parse_async(): %s\n", e.what());
+			ret = false;
+		}
+
+		parsing_success = ret;
+		parsing_done = true;
+	});
+}
+
+ApplicationInfoFilter::ApplicationInfoFilter()
+{
+	impl = new Impl;
+}
+
+void ApplicationInfoFilter::parse_async(const char *path)
+{
+	impl->parse_async(path);
+}
+
+bool ApplicationInfoFilter::test_application_info(const VkApplicationInfo *info)
+{
+	return impl->test_application_info(info);
+}
+
+ApplicationInfoFilter::~ApplicationInfoFilter()
+{
+	delete impl;
+}
+}

--- a/fossilize_application_filter.cpp
+++ b/fossilize_application_filter.cpp
@@ -123,15 +123,15 @@ bool ApplicationInfoFilter::Impl::test_application_info(const VkApplicationInfo 
 		{
 			if (info->engineVersion < itr->second.minimum_engine_version)
 			{
-				LOGI("engineVersion %u is too low for pApplicationName %s. Skipping.\n",
-				     info->engineVersion, info->pApplicationName);
+				LOGI("engineVersion %u is too low for pEngineName %s. Skipping.\n",
+				     info->engineVersion, info->pEngineName);
 				return false;
 			}
 
 			if (info->apiVersion < itr->second.minimum_api_version)
 			{
-				LOGI("apiVersion %u is too low for pApplicationName %s. Skipping.\n",
-				     info->apiVersion, info->pApplicationName);
+				LOGI("apiVersion %u is too low for pEngineName %s. Skipping.\n",
+				     info->apiVersion, info->pEngineName);
 				return false;
 			}
 		}
@@ -218,16 +218,16 @@ static unsigned default_get_member_uint(const Value &value, const char *member, 
 
 static void add_blacklists(std::unordered_set<std::string> &output, const Value *blacklist)
 {
-	if (!blacklist->IsObject())
-		throw std::logic_error("Not an object.");
+	if (!blacklist->IsArray())
+		throw std::logic_error("Not an array.");
 
-	for (auto itr = blacklist->MemberBegin(); itr != blacklist->MemberEnd(); ++itr)
+	for (auto itr = blacklist->Begin(); itr != blacklist->End(); ++itr)
 	{
-		if (!itr->value.IsString())
+		if (!itr->IsString())
 			throw std::logic_error("Not a string.");
 
-		const char *str = itr->value.GetString();
-		output.insert(std::string(str, str + itr->value.GetStringLength()));
+		const char *str = itr->GetString();
+		output.insert(std::string(str, str + itr->GetStringLength()));
 	}
 }
 

--- a/fossilize_application_filter.cpp
+++ b/fossilize_application_filter.cpp
@@ -63,7 +63,15 @@ struct ApplicationInfoFilter::Impl
 	void parse_async(const char *path);
 	bool test_application_info(const VkApplicationInfo *info);
 	bool parse(const std::string &path);
+	bool check_success();
 };
+
+bool ApplicationInfoFilter::Impl::check_success()
+{
+	if (task.valid())
+		task.wait();
+	return parsing_success;
+}
 
 bool ApplicationInfoFilter::Impl::test_application_info(const VkApplicationInfo *info)
 {
@@ -97,7 +105,7 @@ bool ApplicationInfoFilter::Impl::test_application_info(const VkApplicationInfo 
 	if (info->pApplicationName)
 	{
 		auto itr = application_infos.find(info->pApplicationName);
-		if (itr != end(application_infos))
+		if (itr != application_infos.end())
 		{
 			if (info->applicationVersion < itr->second.minimum_application_version)
 			{
@@ -119,7 +127,7 @@ bool ApplicationInfoFilter::Impl::test_application_info(const VkApplicationInfo 
 	if (info->pEngineName)
 	{
 		auto itr = engine_infos.find(info->pEngineName);
-		if (itr != end(application_infos))
+		if (itr != engine_infos.end())
 		{
 			if (info->engineVersion < itr->second.minimum_engine_version)
 			{
@@ -315,6 +323,11 @@ void ApplicationInfoFilter::parse_async(const char *path)
 bool ApplicationInfoFilter::test_application_info(const VkApplicationInfo *info)
 {
 	return impl->test_application_info(info);
+}
+
+bool ApplicationInfoFilter::check_success()
+{
+	return impl->check_success();
 }
 
 ApplicationInfoFilter::~ApplicationInfoFilter()

--- a/fossilize_application_filter.hpp
+++ b/fossilize_application_filter.hpp
@@ -1,0 +1,52 @@
+/* Copyright (c) 2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+struct VkApplicationInfo;
+
+// Allows us to blacklist which applications and which app/engine-versions we don't want to capture.
+namespace Fossilize
+{
+class ApplicationInfoFilter
+{
+public:
+	ApplicationInfoFilter();
+	~ApplicationInfoFilter();
+	void operator=(const ApplicationInfoFilter &) = delete;
+	ApplicationInfoFilter(const ApplicationInfoFilter &) = delete;
+
+	// Path to a JSON file. This is done async to avoid stalling main thread.
+	// Any further query will block.
+	// Called by layer when an instance is created.
+	void parse_async(const char *path);
+
+	// Tests if application should be recorded.
+	// Blocks until parsing is complete. Called by recording thread when preparing for recording.
+	bool test_application_info(const VkApplicationInfo *info);
+
+private:
+	struct Impl;
+	Impl *impl;
+};
+}
+

--- a/fossilize_application_filter.hpp
+++ b/fossilize_application_filter.hpp
@@ -40,6 +40,9 @@ public:
 	// Called by layer when an instance is created.
 	void parse_async(const char *path);
 
+	// Checks if we were successful in parsing the JSON file.
+	bool check_success();
+
 	// Tests if application should be recorded.
 	// Blocks until parsing is complete. Called by recording thread when preparing for recording.
 	bool test_application_info(const VkApplicationInfo *info);

--- a/fossilize_layer.vpc
+++ b/fossilize_layer.vpc
@@ -71,6 +71,7 @@ $Project "fossilize_layer"
 	$Folder "fossilize"
 	{
 		$File ".\fossilize.cpp"
+		$File ".\fossilize_application_filter.cpp"
 		$File ".\fossilize_db.cpp"
 		$File ".\fossilize_external_replayer.cpp"
 		$File ".\path.cpp"

--- a/fossilize_replay.vpc
+++ b/fossilize_replay.vpc
@@ -87,6 +87,7 @@ $Project "fossilize_replay"
 	$Folder "fossilize"
 	{
 		$File ".\fossilize.cpp"
+		$File ".\fossilize_application_filter.cpp"
 		$File ".\fossilize_db.cpp"
 		$File ".\fossilize_external_replayer.cpp"
 		$File ".\path.cpp"

--- a/layer/instance.cpp
+++ b/layer/instance.cpp
@@ -254,6 +254,7 @@ StateRecorder *Instance::getStateRecorderForDevice(const VkApplicationInfo *appI
 		serializationPath = logPath;
 		LOGI("Overriding serialization path: \"%s\".\n", logPath.c_str());
 	}
+	const char *filterPath = nullptr;
 #else
 	serializationPath = "fossilize";
 	const char *path = getenv(FOSSILIZE_DUMP_PATH_ENV);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,12 @@ target_compile_options(varint-test PRIVATE ${FOSSILIZE_CXX_FLAGS})
 set_target_properties(varint-test PROPERTIES LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")
 add_test(NAME varint-system-test COMMAND varint-test)
 
+add_executable(application-info-filter-test application_info_filter_test.cpp)
+target_link_libraries(application-info-filter-test fossilize)
+target_compile_options(application-info-filter-test PRIVATE ${FOSSILIZE_CXX_FLAGS})
+set_target_properties(application-info-filter-test PROPERTIES LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")
+add_test(NAME application-info-filter-test COMMAND application-info-filter-test)
+
 add_executable(multi-instance-and-device-test multi_instance_and_device_test.cpp)
 target_link_libraries(multi-instance-and-device-test cli-utils fossilize)
 set_target_properties(multi-instance-and-device-test PROPERTIES LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")

--- a/test/application_info_filter_test.cpp
+++ b/test/application_info_filter_test.cpp
@@ -1,0 +1,139 @@
+/* Copyright (c) 2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fossilize_application_filter.hpp"
+#include "vulkan.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+static bool write_string_to_file(const char *path, const char *str)
+{
+	FILE *file = fopen(path, "w");
+	if (!file)
+		return false;
+
+	fprintf(file, "%s\n", str);
+	fclose(file);
+	return true;
+}
+
+int main()
+{
+	const char *test_json =
+R"delim(
+{
+	"asset": "FossilizeApplicationInfoFilter",
+	"version" : 1,
+	"blacklistedApplicationNames" : [ "A",  "B", "C" ],
+	"blacklistedEngineNames" : [ "D", "E", "F" ],
+	"applicationFilters" : {
+		"test1" : { "minimumApplicationVersion" : 10 },
+		"test2" : { "minimumApplicationVersion" : 10, "minimumEngineVersion" : 1000 },
+		"test3" : { "minimumApiVersion" : 50 }
+	},
+	"engineFilters" : {
+		"test1" : { "minimumEngineVersion" : 10 },
+		"test2" : { "minimumEngineVersion" : 10, "minimumApplicationVersion" : 1000 },
+		"test3" : { "minimumApiVersion" : 50 }
+	}
+}
+)delim";
+
+	if (!write_string_to_file(".__test_appinfo.json", test_json))
+		return EXIT_FAILURE;
+
+	Fossilize::ApplicationInfoFilter filter;
+	filter.parse_async(".__test_appinfo.json");
+
+	VkApplicationInfo appinfo = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
+
+	if (!filter.test_application_info(nullptr))
+		return EXIT_FAILURE;
+
+	// Test blacklists
+	appinfo.pApplicationName = "A";
+	appinfo.pEngineName = "G";
+	if (filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	appinfo.pApplicationName = "D";
+	appinfo.pEngineName = "A";
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	appinfo.pApplicationName = "H";
+	appinfo.pEngineName = "E";
+	if (filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	// Test application version filtering
+	appinfo.pApplicationName = "test1";
+	appinfo.pEngineName = nullptr;
+	appinfo.applicationVersion = 9;
+	if (filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+	appinfo.applicationVersion = 10;
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	// Engine version should be ignored for appinfo filters.
+	appinfo.pApplicationName = "test2";
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	appinfo.pApplicationName = "test3";
+	appinfo.applicationVersion = 0;
+	appinfo.apiVersion = 49;
+	if (filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	appinfo.apiVersion = 50;
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	// Test engine version filtering
+	appinfo.pApplicationName = nullptr;
+	appinfo.pEngineName = "test1";
+	appinfo.engineVersion = 9;
+	if (filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+	appinfo.engineVersion = 10;
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	// Engine version should be ignored for appinfo filters.
+	appinfo.pEngineName = "test2";
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	appinfo.pEngineName = "test3";
+	appinfo.engineVersion = 0;
+	appinfo.apiVersion = 49;
+	if (filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	appinfo.apiVersion = 50;
+	if (!filter.test_application_info(&appinfo))
+		return EXIT_FAILURE;
+
+	remove(".__test_appinfo.json");
+}

--- a/test/application_info_filter_test.cpp
+++ b/test/application_info_filter_test.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "fossilize_application_filter.hpp"
+#include "layer/utils.hpp"
 #include "vulkan.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,6 +64,12 @@ R"delim(
 
 	Fossilize::ApplicationInfoFilter filter;
 	filter.parse_async(".__test_appinfo.json");
+
+	if (!filter.check_success())
+	{
+		LOGE("Parsing did not complete successfully.\n");
+		return EXIT_FAILURE;
+	}
 
 	VkApplicationInfo appinfo = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
 


### PR DESCRIPTION
This adds support for skipping recording of application infos which are determined to be irrelevant by providing a JSON file with filters. Either appname/enginenames can be blacklisted outright, or we can mandate minimum apiversions, engineversions or applicationversions.