### PR TITLE
Implement an LRU cache for VkShaderModules and support ignoring derived pipelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(fossilize STATIC
         fossilize_types.hpp
         varint.cpp varint.hpp
         fossilize_db.cpp fossilize_db.hpp
+        util/intrusive_list.hpp util/object_pool.hpp util/object_cache.hpp
         path.hpp path.cpp)
 set_target_properties(fossilize PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/cli/device.cpp
+++ b/cli/device.cpp
@@ -292,6 +292,10 @@ bool VulkanDevice::init_device(const Options &opts)
 			active_device_extensions.push_back(ext.extensionName);
 	}
 
+	supports_pipeline_feedback = find_if(begin(active_device_extensions), end(active_device_extensions), [](const char *ext) {
+		return strcmp(ext, VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME) == 0;
+	}) != end(active_device_extensions);
+
 	VkDeviceCreateInfo device_info = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
 	// FIXME: Use physical_device_features2.
 	device_info.pEnabledFeatures = &gpu_features;

--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -62,6 +62,11 @@ public:
 	void set_validation_error_callback(void (*callback)(void *), void *userdata);
 	void notify_validation_error();
 
+	bool pipeline_feedback_enabled() const
+	{
+		return supports_pipeline_feedback;
+	}
+
 private:
 	VkInstance instance = VK_NULL_HANDLE;
 	VkPhysicalDevice gpu = VK_NULL_HANDLE;
@@ -71,5 +76,6 @@ private:
 
 	void (*validation_callback)(void *) = nullptr;
 	void *validation_callback_userdata = nullptr;
+	bool supports_pipeline_feedback = false;
 };
 }

--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -33,6 +33,7 @@ public:
 	{
 		bool enable_validation = false;
 		bool need_disasm = true;
+		bool null_device = false;
 		int device_index = -1;
 		const VkApplicationInfo *application_info = nullptr;
 		const VkPhysicalDeviceFeatures2 *features = nullptr;
@@ -77,5 +78,8 @@ private:
 	void (*validation_callback)(void *) = nullptr;
 	void *validation_callback_userdata = nullptr;
 	bool supports_pipeline_feedback = false;
+
+	void init_null_device();
+	bool is_null_device = false;
 };
 }

--- a/cli/fossilize_prune.cpp
+++ b/cli/fossilize_prune.cpp
@@ -291,8 +291,20 @@ static bool copy_accessed_types(DatabaseInterface &input_db,
 	{
 		size_t compressed_size = 0;
 		if (!input_db.read_entry(tag, hash, &compressed_size, nullptr, PAYLOAD_READ_RAW_FOSSILIZE_DB_BIT))
-			return false;
+		{
+			if (tag == RESOURCE_SHADER_MODULE)
+			{
+				// We did not resolve shader module references, so we might hit an error here, but that's fine.
+				LOGE("Reference shader module %016llx does not exist in database.\n",
+				     static_cast<unsigned long long>(hash));
+				continue;
+			}
+			else
+				return false;
+		}
+
 		state_json.resize(compressed_size);
+
 		if (!input_db.read_entry(tag, hash, &compressed_size, state_json.data(), PAYLOAD_READ_RAW_FOSSILIZE_DB_BIT))
 			return false;
 		if (!output_db.write_entry(tag, hash, state_json.data(), state_json.size(), PAYLOAD_WRITE_RAW_FOSSILIZE_DB_BIT))

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -1949,9 +1949,9 @@ static int run_progress_process(const VulkanDevice::Options &device_opts,
 		}
 	}
 }
-#endif
 
 static void log_process_memory();
+#endif
 
 static int run_normal_process(ThreadedReplayer &replayer, const vector<const char *> &databases)
 {
@@ -2374,8 +2374,10 @@ int main(int argc, char *argv[])
 	{
 		ThreadedReplayer replayer(opts, replayer_opts);
 		ret = run_normal_process(replayer, databases);
+#ifndef NO_ROBUST_REPLAYER
 		if (log_memory)
 			log_process_memory();
+#endif
 	}
 
 	return ret;

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -1791,6 +1791,7 @@ static void print_help()
 	     "\t[--shader-cache-size <value (MiB)>]\n"
 	     "\t[--ignore-derived-pipelines]\n"
 	     "\t[--log-memory]\n"
+	     "\t[--null-device]\n"
 	     EXTRA_OPTIONS
 	     "\t<Database>\n");
 }
@@ -1884,6 +1885,7 @@ static int run_progress_process(const VulkanDevice::Options &device_opts,
 	opts.device_index = device_opts.device_index;
 	opts.enable_validation = device_opts.enable_validation;
 	opts.ignore_derived_pipelines = replayer_opts.ignore_derived_pipelines;
+	opts.null_device = device_opts.null_device;
 
 	ExternalReplayer replayer;
 	if (!replayer.start(opts))
@@ -2146,6 +2148,9 @@ static int run_normal_process(ThreadedReplayer &replayer, const vector<const cha
 		     static_cast<unsigned long long>(tag_total_size_compressed));
 	}
 
+	// Done parsing static objects.
+	state_replayer.get_allocator().reset();
+
 	vector<EnqueuedWork> graphics_workload;
 	vector<EnqueuedWork> compute_workload;
 	replayer.enqueue_deferred_pipelines(replayer.deferred_graphics, replayer.graphics_pipelines, replayer.graphics_parents,
@@ -2304,6 +2309,7 @@ int main(int argc, char *argv[])
 	cbs.add("--shader-cache-size", [&](CLIParser &parser) { replayer_opts.shader_cache_size_mb = parser.next_uint(); });
 	cbs.add("--ignore-derived-pipelines", [&](CLIParser &) { replayer_opts.ignore_derived_pipelines = true; });
 	cbs.add("--log-memory", [&](CLIParser &) { log_memory = true; });
+	cbs.add("--null-device", [&](CLIParser &) { opts.null_device = true; });
 
 	cbs.error_handler = [] { print_help(); };
 

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -320,11 +320,15 @@ struct ThreadedReplayer : StateCreatorInterface
 		per_thread_data.resize(num_worker_threads + 1);
 
 		// Could potentially overflow on 32-bit.
+#if ((SIZE_MAX / (1024 * 1024)) < UINT_MAX)
 		size_t target_size;
 		if (opts.shader_cache_size_mb <= (SIZE_MAX / (1024 * 1024)))
 			target_size = size_t(opts.shader_cache_size_mb) * 1024 * 1024;
 		else
 			target_size = SIZE_MAX;
+#else
+		size_t target_size = size_t(opts.shader_cache_size_mb) * 1024 * 1024;
+#endif
 
 		shader_modules.set_target_size(target_size);
 	}

--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -775,3 +775,21 @@ static int run_slave_process(const VulkanDevice::Options &opts,
 
 	return ret;
 }
+
+static void log_process_memory()
+{
+	char path[1024];
+	sprintf(path, "/proc/%d/status", getpid());
+	FILE *file = fopen(path, "r");
+	if (!file)
+	{
+		LOGE("Failed to log process memory.\n");
+		return;
+	}
+
+	char line_buffer[1024];
+	while (fgets(line_buffer, sizeof(line_buffer), file))
+		fprintf(stderr, "%s", line_buffer);
+
+	fclose(file);
+}

--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -362,6 +362,9 @@ static int run_master_process(const VulkanDevice::Options &opts,
 	Global::base_replayer_options = replayer_opts;
 	Global::databases = databases;
 	unsigned processes = replayer_opts.num_threads;
+
+	// Split shader cache overhead across all processes.
+	Global::base_replayer_options.shader_cache_size_mb /= max(Global::base_replayer_options.num_threads, 1u);
 	Global::base_replayer_options.num_threads = 1;
 
 	// Try to map the shared control block.

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -900,3 +900,8 @@ static int run_slave_process(const VulkanDevice::Options &opts,
 
 	return code;
 }
+
+static void log_process_memory()
+{
+
+}

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -387,7 +387,7 @@ bool ProcessProgress::start_child_process()
 	}
 
 	cmdline += " --shader-cache-size ";
-	cmdline += std::to_string(Global::base_replayer_options.shader_cache_size);
+	cmdline += std::to_string(Global::base_replayer_options.shader_cache_size_mb);
 
 	// Create custom named pipes which can be inherited by our child processes.
 	SECURITY_ATTRIBUTES attrs = {};

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -389,6 +389,9 @@ bool ProcessProgress::start_child_process()
 	cmdline += " --shader-cache-size ";
 	cmdline += std::to_string(Global::base_replayer_options.shader_cache_size_mb);
 
+	if (Global::base_replayer_options.ignore_derived_pipelines)
+		cmdline += " --ignore-derived-pipelines";
+
 	// Create custom named pipes which can be inherited by our child processes.
 	SECURITY_ATTRIBUTES attrs = {};
 	attrs.bInheritHandle = TRUE;

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -370,6 +370,8 @@ bool ProcessProgress::start_child_process()
 		cmdline += " --pipeline-cache";
 	if (Global::base_replayer_options.spirv_validate)
 		cmdline += " --spirv-val";
+	if (Global::device_options.null_device)
+		cmdline += " --null-device";
 
 	if (!Global::base_replayer_options.on_disk_pipeline_cache_path.empty())
 	{

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -386,6 +386,9 @@ bool ProcessProgress::start_child_process()
 		// We're supposed to populate the driver caches here first and foremost.
 	}
 
+	cmdline += " --shader-cache-size ";
+	cmdline += std::to_string(Global::base_replayer_options.shader_cache_size);
+
 	// Create custom named pipes which can be inherited by our child processes.
 	SECURITY_ATTRIBUTES attrs = {};
 	attrs.bInheritHandle = TRUE;
@@ -566,9 +569,12 @@ static int run_master_process(const VulkanDevice::Options &opts,
 	Global::base_replayer_options = replayer_opts;
 	Global::databases = databases;
 	unsigned processes = replayer_opts.num_threads;
-	Global::base_replayer_options.num_threads = 1;
 	Global::shm_name = shm_name;
 	Global::shm_mutex_name = shm_mutex_name;
+
+	// Split shader cache overhead across all processes.
+	Global::base_replayer_options.shader_cache_size_mb /= max(Global::base_replayer_options.num_threads, 1u);
+	Global::base_replayer_options.num_threads = 1;
 
 	Global::job_handle = CreateJobObjectA(nullptr, nullptr);
 	if (!Global::job_handle)

--- a/fossilize.cpp
+++ b/fossilize.cpp
@@ -158,6 +158,7 @@ struct StateReplayer::Impl
 	std::unordered_map<Hash, VkPipeline> replayed_graphics_pipelines;
 
 	void copy_handle_references(const Impl &impl);
+	void forget_handle_references();
 	bool parse_samplers(StateCreatorInterface &iface, const Value &samplers) FOSSILIZE_WARN_UNUSED;
 	bool parse_descriptor_set_layouts(StateCreatorInterface &iface, const Value &layouts) FOSSILIZE_WARN_UNUSED;
 	bool parse_pipeline_layouts(StateCreatorInterface &iface, const Value &layouts) FOSSILIZE_WARN_UNUSED;
@@ -2488,6 +2489,11 @@ void StateReplayer::copy_handle_references(const StateReplayer &replayer)
 	impl->copy_handle_references(*replayer.impl);
 }
 
+void StateReplayer::forget_handle_references()
+{
+	impl->forget_handle_references();
+}
+
 void StateReplayer::Impl::copy_handle_references(const StateReplayer::Impl &other)
 {
 	replayed_samplers = other.replayed_samplers;
@@ -2497,6 +2503,17 @@ void StateReplayer::Impl::copy_handle_references(const StateReplayer::Impl &othe
 	replayed_render_passes = other.replayed_render_passes;
 	replayed_compute_pipelines = other.replayed_compute_pipelines;
 	replayed_graphics_pipelines = other.replayed_graphics_pipelines;
+}
+
+void StateReplayer::Impl::forget_handle_references()
+{
+	replayed_samplers.clear();
+	replayed_descriptor_set_layouts.clear();
+	replayed_pipeline_layouts.clear();
+	replayed_shader_modules.clear();
+	replayed_render_passes.clear();
+	replayed_compute_pipelines.clear();
+	replayed_graphics_pipelines.clear();
 }
 
 bool StateReplayer::Impl::parse(StateCreatorInterface &iface, DatabaseInterface *resolver, const void *buffer_, size_t total_size)

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -156,6 +156,8 @@ public:
 	// Lets other StateReplayers have the same references to objects.
 	void copy_handle_references(const StateReplayer &replayer);
 
+	void forget_handle_references();
+
 	ScratchAllocator &get_allocator();
 
 	// Disable copies (and moves).

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -73,6 +73,9 @@ public:
 		// Ignores derived pipelines, reduces memory consumption when replaying.
 		// Only useful if the driver in question ignores use of derived pipelines when hashing pipelines internally.
 		bool ignore_derived_pipelines;
+
+		// Creates a dummy device, useful for benchmarking time and/or memory consumption in isolation.
+		bool null_device;
 	};
 
 	ExternalReplayer();

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -69,6 +69,10 @@ public:
 
 		// Enable full validation layers.
 		bool enable_validation;
+
+		// Ignores derived pipelines, reduces memory consumption when replaying.
+		// Only useful if the driver in question ignores use of derived pipelines when hashing pipelines internally.
+		bool ignore_derived_pipelines;
 	};
 
 	ExternalReplayer();

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -357,6 +357,9 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		if (options.enable_validation)
 			argv.push_back("--enable-validation");
 
+		if (options.ignore_derived_pipelines)
+			argv.push_back("--ignore-derived-pipelines");
+
 		argv.push_back("--device-index");
 		char index_name[16];
 		sprintf(index_name, "%u", options.device_index);

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -360,6 +360,9 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		if (options.ignore_derived_pipelines)
 			argv.push_back("--ignore-derived-pipelines");
 
+		if (options.null_device)
+			argv.push_back("--null-device");
+
 		argv.push_back("--device-index");
 		char index_name[16];
 		sprintf(index_name, "%u", options.device_index);

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -321,6 +321,9 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	if (options.ignore_derived_pipelines)
 		cmdline += " --ignore-derived-pipelines";
 
+	if (options.null_device)
+		cmdline += " --null-device";
+
 	STARTUPINFO si = {};
 	si.cb = sizeof(STARTUPINFO);
 	si.dwFlags = STARTF_USESTDHANDLES;

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -318,6 +318,9 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	if (options.enable_validation)
 		cmdline += " --enable-validation";
 
+	if (options.ignore_derived_pipelines)
+		cmdline += " --ignore-derived-pipelines";
+
 	STARTUPINFO si = {};
 	si.cb = sizeof(STARTUPINFO);
 	si.dwFlags = STARTF_USESTDHANDLES;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,11 @@ add_executable(multi-instance-and-device-test multi_instance_and_device_test.cpp
 target_link_libraries(multi-instance-and-device-test cli-utils fossilize)
 set_target_properties(multi-instance-and-device-test PROPERTIES LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")
 
+add_executable(object-cache-test object_cache_test.cpp)
+target_link_libraries(object-cache-test fossilize)
+set_target_properties(object-cache-test PROPERTIES LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")
+add_test(NAME object-cache-test COMMAND object-cache-test)
+
 if (NOT WIN32)
     add_executable(futex-test futex_test.cpp)
     target_link_libraries(futex-test fossilize -pthread)

--- a/test/object_cache_test.cpp
+++ b/test/object_cache_test.cpp
@@ -1,0 +1,83 @@
+/* Copyright (c) 2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "util/object_cache.hpp"
+#include "layer/utils.hpp"
+#include <stdlib.h>
+
+using namespace Fossilize;
+
+int main()
+{
+	ObjectCache<int> cache;
+	cache.set_target_size(0);
+
+	// Trivial test, insert two objects and delete the cache.
+	cache.insert_object(1, 1000, 10000);
+	cache.insert_object(2, 2000, 20000);
+	if (cache.get_current_total_size() != 30000)
+		abort();
+
+	cache.delete_cache([](Hash, int object) {
+		LOGI("Deleting object: %d\n", object);
+	});
+
+	if (cache.get_current_total_size() != 0)
+		abort();
+	if (cache.get_current_object_count() != 0)
+		abort();
+
+	// Try inserting lots of objects. Access objects with size 3 and 17.
+	// After pruning, only those two objects should remain.
+	cache.set_target_size(20);
+	for (unsigned i = 0; i < 10000; i++)
+		cache.insert_object(i, i * 1000, i);
+	if (cache.find_object(9999).first != 9999000)
+		abort();
+	if (cache.find_object(3).first != 3000)
+		abort();
+	if (cache.find_object(17).first != 17000)
+		abort();
+
+	cache.prune_cache([](Hash, int) {});
+
+	if (cache.get_current_total_size() != 20)
+		abort();
+	if (cache.get_current_object_count() != 2)
+		abort();
+
+	if (cache.find_object(3).first == 0)
+		abort();
+	if (cache.find_object(17).first == 0)
+		abort();
+	if (cache.find_object(9999).first != 0)
+		abort();
+
+	cache.delete_cache([](Hash, int object) {
+		LOGI("Deleting object: %d\n", object);
+	});
+
+	if (cache.get_current_total_size() != 0)
+		abort();
+	if (cache.get_current_object_count() != 0)
+		abort();
+}

--- a/util/intrusive_list.hpp
+++ b/util/intrusive_list.hpp
@@ -1,0 +1,179 @@
+/* Copyright (c) 2017-2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+namespace Fossilize
+{
+template <typename T>
+struct IntrusiveListEnabled
+{
+	IntrusiveListEnabled<T> *prev = nullptr;
+	IntrusiveListEnabled<T> *next = nullptr;
+};
+
+template <typename T>
+class IntrusiveList
+{
+public:
+	void clear()
+	{
+		head = nullptr;
+		tail = nullptr;
+	}
+
+	class Iterator
+	{
+	public:
+		friend class IntrusiveList<T>;
+		Iterator(IntrusiveListEnabled<T> *node_)
+		    : node(node_)
+		{
+		}
+
+		Iterator() = default;
+
+		explicit operator bool() const
+		{
+			return node != nullptr;
+		}
+
+		bool operator==(const Iterator &other) const
+		{
+			return node == other.node;
+		}
+
+		bool operator!=(const Iterator &other) const
+		{
+			return node != other.node;
+		}
+
+		T &operator*()
+		{
+			return *static_cast<T *>(node);
+		}
+
+		const T &operator*() const
+		{
+			return *static_cast<T *>(node);
+		}
+
+		T *get()
+		{
+			return static_cast<T *>(node);
+		}
+
+		const T *get() const
+		{
+			return static_cast<const T *>(node);
+		}
+
+		T *operator->()
+		{
+			return static_cast<T *>(node);
+		}
+
+		const T *operator->() const
+		{
+			return static_cast<T *>(node);
+		}
+
+		Iterator &operator++()
+		{
+			node = node->next;
+			return *this;
+		}
+
+		Iterator &operator--()
+		{
+			node = node->prev;
+			return *this;
+		}
+
+	private:
+		IntrusiveListEnabled<T> *node = nullptr;
+	};
+
+	Iterator begin()
+	{
+		return Iterator(head);
+	}
+
+	Iterator rbegin()
+	{
+		return Iterator(tail);
+	}
+
+	Iterator end()
+	{
+		return Iterator();
+	}
+
+	Iterator erase(Iterator itr)
+	{
+		auto *node = itr.get();
+		auto *next = node->next;
+		auto *prev = node->prev;
+
+		if (prev)
+			prev->next = next;
+		else
+			head = next;
+
+		if (next)
+			next->prev = prev;
+		else
+			tail = prev;
+
+		return next;
+	}
+
+	void insert_front(Iterator itr)
+	{
+		auto *node = itr.get();
+
+		if (head)
+			head->prev = node;
+		else
+			tail = node;
+
+		node->next = head;
+		node->prev = nullptr;
+		head = node;
+	}
+
+	void move_to_front(IntrusiveList<T> &other, Iterator itr)
+	{
+		other.erase(itr);
+		insert_front(itr);
+	}
+
+	bool empty() const
+	{
+		return head == nullptr;
+	}
+
+private:
+	IntrusiveListEnabled<T> *head = nullptr;
+	IntrusiveListEnabled<T> *tail = nullptr;
+};
+}

--- a/util/object_cache.hpp
+++ b/util/object_cache.hpp
@@ -1,0 +1,136 @@
+/* Copyright (c) 2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include "fossilize_types.hpp"
+#include "object_pool.hpp"
+#include "intrusive_list.hpp"
+#include <assert.h>
+
+namespace Fossilize
+{
+template <typename T>
+class ObjectCache
+{
+public:
+	ObjectCache() = default;
+	ObjectCache(const ObjectCache &) = delete;
+	void operator=(const ObjectCache &) = delete;
+
+	~ObjectCache()
+	{
+		assert(lru_cache.empty());
+	}
+
+	void set_target_size(size_t size)
+	{
+		target_size = size;
+	}
+
+	std::pair<T, bool> find_object(Hash hash)
+	{
+		auto itr = hash_to_objects.find(hash);
+		if (itr == std::end(hash_to_objects))
+			return { static_cast<T>(0), false };
+
+		lru_cache.move_to_front(lru_cache, itr->second);
+		return { itr->second->object, true };
+	}
+
+	template <typename Deleter>
+	void prune_cache(const Deleter &deleter)
+	{
+		while (total_size > target_size)
+		{
+			assert(!lru_cache.empty());
+			auto last_used_entry = lru_cache.rbegin();
+			assert(last_used_entry->size <= total_size);
+			total_size -= last_used_entry->size;
+			lru_cache.erase(last_used_entry);
+
+			deleter(last_used_entry->hash, last_used_entry->object);
+			hash_to_objects.erase(last_used_entry->hash);
+			pool.free(last_used_entry.get());
+		}
+	}
+
+	template <typename Deleter>
+	void delete_cache(const Deleter &deleter)
+	{
+		auto itr = lru_cache.begin();
+		while (itr != std::end(lru_cache))
+		{
+			auto entry = itr;
+			itr = lru_cache.erase(entry);
+			deleter(entry->hash, entry->object);
+			assert(entry->size <= total_size);
+			total_size -= entry->size;
+			pool.free(entry.get());
+		}
+
+		lru_cache.clear();
+		hash_to_objects.clear();
+		assert(total_size == 0);
+	}
+
+	void insert_object(Hash hash, T object, size_t object_size)
+	{
+		auto *entry = pool.allocate();
+		entry->hash = hash;
+		entry->object = object;
+		entry->size = object_size;
+		lru_cache.insert_front(entry);
+		auto map_itr = hash_to_objects.insert({ hash, entry });
+		(void)map_itr;
+		assert(map_itr.second);
+
+		total_size += object_size;
+	}
+
+	size_t get_current_total_size() const
+	{
+		return total_size;
+	}
+
+	size_t get_current_object_count() const
+	{
+		return hash_to_objects.size();
+	}
+
+private:
+	size_t target_size = 0;
+	size_t total_size = 0;
+
+	struct CacheEntry : IntrusiveListEnabled<CacheEntry>
+	{
+		T object = static_cast<T>(0);
+		Hash hash = 0;
+		size_t size = 0;
+	};
+
+	ObjectPool<CacheEntry> pool;
+	std::unordered_map<Hash, CacheEntry *> hash_to_objects;
+	IntrusiveList<CacheEntry> lru_cache;
+};
+}

--- a/util/object_pool.hpp
+++ b/util/object_pool.hpp
@@ -69,7 +69,6 @@ public:
 	}
 
 protected:
-#ifndef OBJECT_POOL_DEBUG
 	std::vector<T *> vacants;
 
 	struct MallocDeleter
@@ -81,6 +80,5 @@ protected:
 	};
 
 	std::vector<std::unique_ptr<T, MallocDeleter>> memory;
-#endif
 };
 }

--- a/util/object_pool.hpp
+++ b/util/object_pool.hpp
@@ -1,0 +1,86 @@
+/* Copyright (c) 2017-2019 Hans-Kristian Arntzen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+#include <algorithm>
+#include <stdlib.h>
+
+namespace Fossilize
+{
+template<typename T>
+class ObjectPool
+{
+public:
+	template<typename... P>
+	T *allocate(P &&... p)
+	{
+		if (vacants.empty())
+		{
+			unsigned num_objects = 64u << memory.size();
+			T *ptr = static_cast<T *>(malloc(num_objects * sizeof(T)));
+			if (!ptr)
+				return nullptr;
+
+			for (unsigned i = 0; i < num_objects; i++)
+				vacants.push_back(&ptr[i]);
+
+			memory.emplace_back(ptr);
+		}
+
+		T *ptr = vacants.back();
+		vacants.pop_back();
+		new(ptr) T(std::forward<P>(p)...);
+		return ptr;
+	}
+
+	void free(T *ptr)
+	{
+		ptr->~T();
+		vacants.push_back(ptr);
+	}
+
+	void clear()
+	{
+		vacants.clear();
+		memory.clear();
+	}
+
+protected:
+#ifndef OBJECT_POOL_DEBUG
+	std::vector<T *> vacants;
+
+	struct MallocDeleter
+	{
+		void operator()(T *ptr)
+		{
+			::free(ptr);
+		}
+	};
+
+	std::vector<std::unique_ptr<T, MallocDeleter>> memory;
+#endif
+};
+}


### PR DESCRIPTION
During replay, memory use to keep VkShaderModules around can get very large. To combat this, we implement a simple cache which bounds how much memory is dedicated to keep VkShaderModule objects around.

As a final measure to reduce "unbounded" number of objects to keep around, we can ignore VK_PIPELINE_CREATE_DERIVED_BIT. If drivers happen to ignore this flag as part of pipeline caching, this can be a nice memory save as no pipelines will need to be kept alive as part of being used a basePipelineHandle. It remains to be seen how useful this is, but the feature is trivial enough.

Finally, to better test DERIVED_BIT, this PR also supports using VK_EXT_pipeline_creation_feedback to get a rough idea how pipeline caches behave.
