### PR TITLE
Implement validation whitelists and blacklists

### DIFF
--- a/cli/device.cpp
+++ b/cli/device.cpp
@@ -297,7 +297,17 @@ bool VulkanDevice::init_device(const Options &opts)
 
 		// FIXME: This will not work on Android, use "shopping list of layers" method. :(
 		if (find_layer(device_layers, "VK_LAYER_LUNARG_standard_validation"))
+		{
 			active_device_layers.push_back("VK_LAYER_LUNARG_standard_validation");
+
+			uint32_t validation_ext_count = 0;
+			vkEnumerateDeviceExtensionProperties(gpu, "VK_LAYER_LUNARG_standard_validation", &validation_ext_count, nullptr);
+			vector<VkExtensionProperties> validation_extensions(validation_ext_count);
+			vkEnumerateDeviceExtensionProperties(gpu, "VK_LAYER_LUNARG_standard_validation", &validation_ext_count, validation_extensions.data());
+			validation_cache = find_extension(validation_extensions, VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
+			if (validation_cache)
+				active_device_extensions.push_back(VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
+		}
 	}
 
 	uint32_t device_ext_count = 0;

--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -74,6 +74,11 @@ public:
 		return pipeline_stats;
 	}
 
+	bool has_validation_cache() const
+	{
+		return validation_cache;
+	}
+
 private:
 	VkInstance instance = VK_NULL_HANDLE;
 	VkPhysicalDevice gpu = VK_NULL_HANDLE;
@@ -88,5 +93,6 @@ private:
 	void init_null_device();
 	bool is_null_device = false;
 	bool pipeline_stats = false;
+	bool validation_cache = false;
 };
 }

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -2122,9 +2122,11 @@ static int run_progress_process(const VulkanDevice::Options &device_opts,
 {
 	ExternalReplayer::Options opts = {};
 	opts.on_disk_pipeline_cache = replayer_opts.on_disk_pipeline_cache_path.empty() ?
-		nullptr : replayer_opts.on_disk_pipeline_cache_path.c_str();
+	                              nullptr : replayer_opts.on_disk_pipeline_cache_path.c_str();
+	opts.on_disk_validation_cache = replayer_opts.on_disk_validation_cache_path.empty() ?
+	                                nullptr : replayer_opts.on_disk_validation_cache_path.c_str();
 	opts.pipeline_stats_path = replayer_opts.pipeline_stats_path.empty() ?
-		nullptr : replayer_opts.pipeline_stats_path.c_str();
+	                           nullptr : replayer_opts.pipeline_stats_path.c_str();
 	opts.pipeline_cache = replayer_opts.pipeline_cache;
 	opts.num_threads = replayer_opts.num_threads;
 	opts.quiet = true;

--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -347,6 +347,12 @@ bool ProcessProgress::start_child_process()
 			copy_opts.on_disk_pipeline_cache_path += std::to_string(index);
 		}
 
+		if (!copy_opts.on_disk_validation_cache_path.empty() && index != 0)
+		{
+			copy_opts.on_disk_validation_cache_path += ".";
+			copy_opts.on_disk_validation_cache_path += std::to_string(index);
+		}
+
 		if (!copy_opts.pipeline_stats_path.empty() && index != 0)
 		{
 			copy_opts.pipeline_stats_path += ".";

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -403,6 +403,22 @@ bool ProcessProgress::start_child_process()
 		// TODO: Merge the on-disk validation caches, but it's probably not that important.
 	}
 
+	if (!Global::base_replayer_options.on_disk_validation_whitelist_path.empty())
+	{
+		cmdline += " --on-disk-validation-whitelist ";
+		cmdline += "\"";
+		cmdline += Global::base_replayer_options.on_disk_validation_whitelist_path;
+		cmdline += "\"";
+	}
+
+	if (!Global::base_replayer_options.on_disk_validation_blacklist_path.empty())
+	{
+		cmdline += " --on-disk-validation-blacklist ";
+		cmdline += "\"";
+		cmdline += Global::base_replayer_options.on_disk_validation_blacklist_path;
+		cmdline += "\"";
+	}
+
 	cmdline += " --shader-cache-size ";
 	cmdline += std::to_string(Global::base_replayer_options.shader_cache_size_mb);
 

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -389,6 +389,20 @@ bool ProcessProgress::start_child_process()
 		// We're supposed to populate the driver caches here first and foremost.
 	}
 
+	if (!Global::base_replayer_options.on_disk_validation_cache_path.empty())
+	{
+		cmdline += " --on-disk-validation-cache ";
+		cmdline += "\"";
+		cmdline += Global::base_replayer_options.on_disk_validation_cache_path;
+		if (index != 0)
+		{
+			cmdline += ".";
+			cmdline += std::to_string(index);
+		}
+		cmdline += "\"";
+		// TODO: Merge the on-disk validation caches, but it's probably not that important.
+	}
+
 	cmdline += " --shader-cache-size ";
 	cmdline += std::to_string(Global::base_replayer_options.shader_cache_size_mb);
 

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -69,13 +69,33 @@ enum PayloadReadFlagBits
 using PayloadWriteFlags = uint32_t;
 using PayloadReadFlags = uint32_t;
 
+enum class DatabaseMode
+{
+	Append,
+	ReadOnly,
+	OverWrite,
+	// In the stream database backend, this will ensure that the database is exclusively created.
+	// For other backends, this is an alias for OverWrite
+			ExclusiveOverWrite
+};
+
 // This is an interface to interact with an external database for blob modules.
 // It is is a simple database with key + blob.
 // NOTE: The database is NOT thread-safe.
 class DatabaseInterface
 {
 public:
-	virtual ~DatabaseInterface() = default;
+	DatabaseInterface(DatabaseMode mode);
+	virtual ~DatabaseInterface();
+
+	// Loads a white-list and/or blacklist database which filters
+	// which entries are retrieved through get_hash_list_for_resource_tag.
+	// The database is a stream archive (.foz) with 0-sized blobs for tags
+	// SHADER_MODULE, COMPUTE_PIPELINE, GRAPHICS_PIPELINE.
+	// This must be called before prepare().
+	// Can only be used for ReadOnly database mode.
+	bool load_whitelist_database(const char *path);
+	bool load_blacklist_database(const char *path);
 
 	// Prepares the database. It can load in the off-line archive from disk.
 	virtual bool prepare() = 0;
@@ -100,16 +120,11 @@ public:
 	virtual void flush() = 0;
 
 	virtual const char *get_db_path_for_hash(ResourceTag tag, Hash hash) = 0;
-};
 
-enum class DatabaseMode
-{
-	Append,
-	ReadOnly,
-	OverWrite,
-	// In the stream database backend, this will ensure that the database is exclusively created.
-	// For other backends, this is an alias for OverWrite
-	ExclusiveOverWrite
+protected:
+	bool test_resource_filter(ResourceTag tag, Hash hash) const;
+	struct Impl;
+	Impl *impl;
 };
 
 DatabaseInterface *create_dumb_folder_database(const char *directory_path, DatabaseMode mode);

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -76,7 +76,7 @@ enum class DatabaseMode
 	OverWrite,
 	// In the stream database backend, this will ensure that the database is exclusively created.
 	// For other backends, this is an alias for OverWrite
-			ExclusiveOverWrite
+	ExclusiveOverWrite
 };
 
 // This is an interface to interact with an external database for blob modules.

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -45,6 +45,9 @@ public:
 		// Path to an on-disk pipeline cache. Maps to --on-disk-pipeline-cache.
 		const char *on_disk_pipeline_cache;
 
+		// Path to an on-disk validation cache. Maps to --on-disk-validation-cache.
+		const char *on_disk_validation_cache;
+
 		// Path to store pipeline stats in.
 		const char *pipeline_stats_path;
 

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -48,6 +48,10 @@ public:
 		// Path to an on-disk validation cache. Maps to --on-disk-validation-cache.
 		const char *on_disk_validation_cache;
 
+		// Path to on-disk validation white/blacklists.
+		const char *on_disk_validation_whitelist;
+		const char *on_disk_validation_blacklist;
+
 		// Path to store pipeline stats in.
 		const char *pipeline_stats_path;
 

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -360,6 +360,18 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 			argv.push_back(options.on_disk_validation_cache);
 		}
 
+		if (options.on_disk_validation_whitelist)
+		{
+			argv.push_back("--on-disk-validation-whitelist");
+			argv.push_back(options.on_disk_validation_whitelist);
+		}
+
+		if (options.on_disk_validation_blacklist)
+		{
+			argv.push_back("--on-disk-validation-blacklist");
+			argv.push_back(options.on_disk_validation_blacklist);
+		}
+
 		if (options.enable_validation)
 			argv.push_back("--enable-validation");
 

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -354,6 +354,12 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 			argv.push_back(options.on_disk_pipeline_cache);
 		}
 
+		if (options.on_disk_validation_cache)
+		{
+			argv.push_back("--on-disk-validation-cache");
+			argv.push_back(options.on_disk_validation_cache);
+		}
+
 		if (options.enable_validation)
 			argv.push_back("--enable-validation");
 

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -330,7 +330,7 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 
 	if (options.on_disk_validation_blacklist)
 	{
-		cmdline += " --on-disk-validation-blaclist ";
+		cmdline += " --on-disk-validation-blacklist ";
 		cmdline += "\"";
 		cmdline += options.on_disk_validation_blacklist;
 		cmdline += "\"";

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -320,6 +320,22 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		cmdline += "\"";
 	}
 
+	if (options.on_disk_validation_whitelist)
+	{
+		cmdline += " --on-disk-validation-whitelist ";
+		cmdline += "\"";
+		cmdline += options.on_disk_validation_whitelist;
+		cmdline += "\"";
+	}
+
+	if (options.on_disk_validation_blacklist)
+	{
+		cmdline += " --on-disk-validation-blaclist ";
+		cmdline += "\"";
+		cmdline += options.on_disk_validation_blacklist;
+		cmdline += "\"";
+	}
+
 	cmdline += " --device-index ";
 	cmdline += std::to_string(options.device_index);
 

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -312,6 +312,14 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		cmdline += "\"";
 	}
 
+	if (options.on_disk_validation_cache)
+	{
+		cmdline += " --on-disk-validation-cache ";
+		cmdline += "\"";
+		cmdline += options.on_disk_validation_cache;
+		cmdline += "\"";
+	}
+
 	cmdline += " --device-index ";
 	cmdline += std::to_string(options.device_index);
 


### PR DESCRIPTION
Allows the replayer to maintain a cache of pipelines and modules which are known to have replayed successfully without validation error. Blacklists are the converse, recording blobs which failed validation.