### PR TITLE
Use absolute paths for installed JSON file.

### DIFF
--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -47,10 +47,10 @@ else()
 	if (NOT ANDROID)
 		if (APPLE)
 			# Second one is for installation, where we want to rely on LD_LIBRARY_PATH
-			set(FOSSILIZE_LAYER_PATH "libVkLayer_fossilize.dylib")
+			set(FOSSILIZE_LAYER_PATH "${CMAKE_INSTALL_PREFIX}/lib/libVkLayer_fossilize.dylib")
 		else()
 			# Second one is for installation, where we want to rely on LD_LIBRARY_PATH
-			set(FOSSILIZE_LAYER_PATH "libVkLayer_fossilize.so")
+			set(FOSSILIZE_LAYER_PATH "${CMAKE_INSTALL_PREFIX}/lib/libVkLayer_fossilize.so")
 		endif()
 		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_fossilize.json.in ${CMAKE_BINARY_DIR}/VkLayer_fossilize.json @ONLY)
 		install(FILES ${CMAKE_BINARY_DIR}/VkLayer_fossilize.json DESTINATION share/vulkan/explicit_layer.d)


### PR DESCRIPTION
Avoids having to make sure installed files are in LD_LIBRARY_PATH.

Fix #48.