### PR TITLE
Add support for a timeout during pipeline compilation.

### DIFF
--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -205,7 +205,9 @@ struct EnqueuedWork
 };
 
 static void on_validation_error(void *userdata);
+#ifndef NO_ROBUST_REPLAYER
 static void timeout_handler();
+#endif
 
 struct ThreadedReplayer : StateCreatorInterface
 {
@@ -434,8 +436,12 @@ struct ThreadedReplayer : StateCreatorInterface
 				                                                });
 				if (!signalled && completed_count[index] == current_completed)
 				{
-					// Timeout!
+#ifndef NO_ROBUST_REPLAYER
 					timeout_handler();
+#else
+					LOGE("Timed out replaying pipelines!\n");
+					exit(2);
+#endif
 				}
 
 				current_completed = completed_count[index];

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -94,6 +94,10 @@ public:
 
 		// Creates a dummy device, useful for benchmarking time and/or memory consumption in isolation.
 		bool null_device;
+
+		// If non-zero, enables a timeout for pipeline compilation to have forward progress on drivers
+		// which enter infinite loops during compilation.
+		unsigned timeout_seconds;
 	};
 
 	ExternalReplayer();

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -410,6 +410,14 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 			argv.push_back(options.pipeline_stats_path);
 		}
 
+		char timeout[16];
+		if (options.timeout_seconds)
+		{
+			argv.push_back("--timeout-seconds");
+			sprintf(timeout, "%u", options.timeout_seconds);
+			argv.push_back(timeout);
+		}
+
 		argv.push_back(nullptr);
 
 		if (options.quiet)

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -369,6 +369,12 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		cmdline += "\"";
 	}
 
+	if (options.timeout_seconds)
+	{
+		cmdline += " --timeout-seconds ";
+		cmdline += std::to_string(options.timeout_seconds);
+	}
+
 	STARTUPINFO si = {};
 	si.cb = sizeof(STARTUPINFO);
 	si.dwFlags = STARTF_USESTDHANDLES;


### PR DESCRIPTION
It is possible that drivers just enter an infinite loop when attempting
to compile pipelines. In this case, we just pretend to crash and keep
forward progress going.

Fix #55.