### PR TITLE
⚡ Move most conditional logic to generator expressions (and other patches)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,54 +1,102 @@
 cmake_minimum_required(VERSION 3.5)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
 project(Fossilize LANGUAGES CXX C)
 
-option(FOSSILIZE_MSVC_ANALYZE "Enable /analyze" OFF)
-option(FOSSILIZE_ENABLE_EXCEPTIONS "Compile Fossilize with exception support." OFF)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+set(CMAKE_THREA_PREFER_PTHREAD ON)
 
-if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-    if (NOT FOSSILIZE_ENABLE_EXCEPTIONS)
-        set(FOSSILIZE_EXCEPTION_FLAGS "-fno-exceptions")
-    else()
-        set(FOSSILIZE_EXCEPTION_FLAGS "")
-    endif()
-    set(FOSSILIZE_CXX_FLAGS -Wall -Wextra -Wunused-result -Wno-missing-field-initializers -Wno-empty-body -Wshadow ${FOSSILIZE_EXCEPTION_FLAGS})
-elseif (MSVC)
-    if (FOSSILIZE_MSVC_ANALYZE)
-        set(FOSSILIZE_ANALYZE_FLAGS "/analyze")
-    else()
-        set(FOSSILIZE_ANALYZE_FLAGS "")
-    endif()
-    # Disabling exceptions in MSVC without a ton of scary warnings is quite finicky.
-    # Don't bother. We can verify no exceptions are present with -fno-exceptions on GCC/Clang.
-    set(FOSSILIZE_CXX_FLAGS ${FOSSILIZE_ANALYZE_FLAGS} /D_CRT_SECURE_NO_WARNINGS /D_SCL_SECURE_NO_WARNINGS /wd4267 /wd4244 /wd4309 /wd4005 /MP /DNOMINMAX)
+include(CMakeDependentOption)
+include(GNUInstallDirs)
+include(CTest)
+
+find_package(Threads REQUIRED)
+find_package(Vulkan)
+
+if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 14)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
+if (NOT DEFINED CMAKE_C_STANDARD OR CMAKE_C_STANDARD LESS 99)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+if (NOT DEFINED CMAKE_CXX_VISIBILITY_PRESET)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+endif()
+
+if (NOT DEFINED CMAKE_C_VISIBILITY_PRESET)
+  set(CMAKE_C_VISIBILITY_PRESET hidden)
+endif()
+
+cmake_dependent_option(FOSSILIZE_TESTS
+  "Enable Fossilize tests" ON
+  "CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME;BUILD_TESTING" OFF)
+
+option(FOSSILIZE_ENABLE_EXCEPTIONS "Compile Fossilize with exception support." OFF)
+option(FOSSILIZE_MSVC_ANALYZE "Enable /analyze" OFF)
+# Not needed for position-independent-code, as its always turned on
+option(FOSSILIZE_VULKAN_LAYER "Build Vulkan layer." ON) 
+option(FOSSILIZE_CLI "Enable Fossilize CLI support." ON)
 
 option(FOSSILIZE_SANITIZE_ADDRESS "Sanitize address" OFF)
-set(FOSSILIZE_LINK_FLAGS)
-if (FOSSILIZE_SANITIZE_ADDRESS)
-    set(FOSSILIZE_CXX_FLAGS ${FOSSILIZE_CXX_FLAGS} -fsanitize=address)
-    set(FOSSILIZE_LINK_FLAGS "${FOSSILIZE_LINK_FLAGS} -fsanitize=address")
-endif()
-
 option(FOSSILIZE_SANITIZE_THREADS "Sanitize threads" OFF)
-if (FOSSILIZE_SANITIZE_THREADS)
-    set(FOSSILIZE_CXX_FLAGS ${FOSSILIZE_CXX_FLAGS} -fsanitize=thread)
-    set(FOSSILIZE_LINK_FLAGS "${FOSSILIZE_LINK_FLAGS} -fsanitize=thread")
+
+# option() cannot technically be used in newer CMake versions for non-boolean values
+# warnings will be thrown and this can be annoying otherwise.
+set(FOSSILIZE_VULKAN_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/khronos/vulkan"
+  CACHE PATH "include path for vulkan headers")
+set(FOSSILIZE_RAPIDJSON_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/rapidjson/include"
+  CACHE PATH "include path for rapidjson headers")
+
+# TODO: Gate all of this behind a better generator expression
+if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    list(APPEND FOSSILIZE_CXX_FLAGS
+      -Wall -Wextra -Wunused-result -Wno-missing-field-initializers -Wno-empty-body -Wshadow
+      $<$<NOT:$<BOOL:${FOSSILIZE_ENABLE_EXCEPTIONS}>>:-fno-exceptions>)
+elseif (MSVC)
+    # XXX: This can be done, and safely, but will require more work and a more recent version of CMake
+    # Disabling exceptions in MSVC without a ton of scary warnings is quite finicky.
+    # Don't bother. We can verify no exceptions are present with -fno-exceptions on GCC/Clang.
+    list(APPEND FOSSILIZE_CXX_FLAGS
+      $<$<BOOL:${FOSSILIZE_MSVC_ANALYZE}>:/analyze>
+      /wd4267
+      /wd4244
+      /wd4309
+      /wd4005
+      /MP)
 endif()
 
-include(GNUInstallDirs)
+# TODO: This does not currently support the MSVC support for AddressSanitizer
+if (FOSSILIZE_SANITIZE_ADDRESS)
+    list(APPEND FOSSILIZE_CXX_FLAGS -fsanitize=address)
+    list(APPEND FOSSILIZE_LINK_FLAGS -fsanitize=address)
+endif()
 
-add_library(miniz STATIC miniz/miniz.h miniz/miniz.c)
-set_target_properties(miniz PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_include_directories(miniz PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/miniz)
-if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
-    target_compile_options(miniz PRIVATE -fvisibility=hidden)
-    if (NOT APPLE AND NOT ANDROID)
-        target_compile_definitions(miniz PRIVATE _LARGEFILE64_SOURCE)
-    endif()
+if (FOSSILIZE_SANITIZE_THREADS)
+    list(APPEND FOSSILIZE_CXX_FLAGS -fsanitize=thread)
+    list(APPEND FOSSILIZE_LINK_FLAGS -fsanitize=thread)
+endif()
+
+if (NOT TARGET miniz)
+  add_library(miniz STATIC miniz/miniz.h miniz/miniz.c)
+  set_target_properties(miniz PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(miniz
+    PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/miniz>)
+  string(CONCAT largefile $<AND:
+    $<OR:
+      $<CXX_COMPILER_ID:GNU>,
+      $<CXX_COMPILER_ID:Clang>,
+      $<CXX_COMPILER_ID:AppleClang>
+    >,
+    $<NOT:
+      $<AND:
+        $<PLATFORM_ID:Darwin>,
+        $<PLATFORM_ID:Android>
+      >
+    >
+  >)
+  target_compile_definitions(miniz PRIVATE $<${largefile}:_LARGEFILE64_SOURCE>)
 endif()
 
 add_library(fossilize STATIC
@@ -63,75 +111,51 @@ add_library(fossilize STATIC
         path.hpp path.cpp)
 set_target_properties(fossilize PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-if (WIN32 AND CMAKE_COMPILER_IS_GNUCXX)
-	target_compile_definitions(fossilize PUBLIC __USE_MINGW_ANSI_STDIO=1)
-endif()
-
-if (NOT ANDROID)
-    target_sources(fossilize PRIVATE fossilize_external_replayer.cpp fossilize_external_replayer.hpp)
-endif()
-
-if (WIN32)
-    target_sources(fossilize PRIVATE fossilize_external_replayer_windows.hpp)
-else()
-    target_sources(fossilize PRIVATE fossilize_external_replayer_linux.hpp)
-    if (APPLE)
-        target_sources(fossilize PRIVATE platform/gcc_clang_spinlock.hpp)
-    else()
-        target_sources(fossilize PRIVATE platform/futex_wrapper_linux.hpp)
-    endif()
-endif()
-
-target_include_directories(fossilize PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(fossilize
+  PUBLIC
+    $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
+    $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>
+    $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>
+    $<$<AND:$<PLATFORM_ID:Windows>,$<CXX_COMPILER_ID:GNU>>:__USE_MINGW_ANSI_STDIO=1>)
+target_sources(fossilize
+  PRIVATE
+    $<$<NOT:$<PLATFORM_ID:Android>>:fossilize_external_replayer.cpp>
+    $<$<NOT:$<PLATFORM_ID:Android>>:fossilize_external_replayer.hpp>
+    $<$<NOT:$<PLATFORM_ID:Windows>>:fossilize_external_replayer_linux.hpp>
+    $<$<PLATFORM_ID:Windows>:fossilize_external_replayer_windows.hpp>
+    $<$<PLATFORM_ID:Darwin>:platform/gcc_clang_spinlock.hpp>
+    $<$<PLATFORM_ID:Linux>:platform/futex_wrapper_linux.hpp>)
+target_include_directories(fossilize
+  PUBLIC
+    $<BUILD_INTERFACE:$<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/cli/dirent/include>>
+    $<BUILD_INTERFACE:${FOSSILIZE_RAPIDJSON_INCLUDE_PATH}>
+    $<BUILD_INTERFACE:${FOSSILIZE_VULKAN_INCLUDE_PATH}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_options(fossilize PRIVATE ${FOSSILIZE_CXX_FLAGS})
-if (NOT WIN32)
-    target_link_libraries(fossilize -pthread)
-    target_compile_options(fossilize PUBLIC -pthread)
-    if (NOT APPLE)
-        if (ANDROID)
-            target_link_libraries(fossilize android log)
-        else()
-            target_link_libraries(fossilize rt)
-        endif()
-    endif()
-endif()
-target_link_libraries(fossilize miniz)
+target_link_libraries(fossilize
+  PRIVATE
+    $<TARGET_NAME_IF_EXISTS:Vulkan::Vulkan>
+    Threads::Threads
+    $<$<PLATFORM_ID:Android>:android>
+    $<$<PLATFORM_ID:Android>:log>
+    $<$<PLATFORM_ID:Linux>:rt>
+    miniz)
 
-if (WIN32)
-    target_include_directories(fossilize PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cli/dirent/include)
-endif()
-
-option(FOSSILIZE_VULKAN_LAYER "Build Vulkan layer." ON)
-if (FOSSILIZE_VULKAN_LAYER)
-    set_target_properties(fossilize PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif()
-
-option(FOSSILIZE_RAPIDJSON_INCLUDE_PATH "Optional custom include path for rapidjson.")
-if (FOSSILIZE_RAPIDJSON_INCLUDE_PATH)
-    target_include_directories(fossilize PUBLIC ${FOSSILIZE_RAPIDJSON_INCLUDE_PATH})
+if (CMAKE_VERSION LESS 3.13)
+  set_property(TARGET fossilize APPEND_STRING PROPERTY LINK_FLAGS ${FOSSILIZE_LINK_FLAGS})
 else()
-    target_include_directories(fossilize PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/rapidjson/include)
-endif()
-
-option(FOSSILIZE_VULKAN_INCLUDE_PATH "Optional custom include path for Vulkan headers.")
-if (FOSSILIZE_VULKAN_INCLUDE_PATH)
-    target_include_directories(fossilize PUBLIC ${FOSSILIZE_VULKAN_INCLUDE_PATH})
-else()
-    target_include_directories(fossilize PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/khronos/vulkan)
+  target_link_options(fossilize PRIVATE ${FOSSILIZE_LINK_FLAGS})
 endif()
 
 if (FOSSILIZE_VULKAN_LAYER)
     add_subdirectory(layer)
 endif()
 
-option(FOSSILIZE_CLI "Enable Fossilize CLI support." ON)
 if (FOSSILIZE_CLI)
     add_subdirectory(cli)
 endif()
 
-option(FOSSILIZE_TESTS "Enable Fossilize tests." ON)
 if (FOSSILIZE_TESTS)
-    enable_testing()
     add_subdirectory(test)
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,13 @@ set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
 project(Fossilize LANGUAGES CXX C)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-set(CMAKE_THREA_PREFER_PTHREAD ON)
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
 
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 include(CTest)
 
 find_package(Threads REQUIRED)
-find_package(Vulkan)
 
 if (NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 14)
   set(CMAKE_CXX_STANDARD 14)
@@ -77,24 +76,28 @@ if (FOSSILIZE_SANITIZE_THREADS)
     list(APPEND FOSSILIZE_LINK_FLAGS -fsanitize=thread)
 endif()
 
+# Temporary variables to mmake some generator expressions more readable
+
+
 if (NOT TARGET miniz)
   add_library(miniz STATIC miniz/miniz.h miniz/miniz.c)
   set_target_properties(miniz PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_include_directories(miniz
     PUBLIC
       $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/miniz>)
+  string(CONCAT cxx-is-clang $<OR:
+    $<CXX_COMPILER_ID:AppleClang>,
+    $<CXX_COMPILER_ID:Clang>
+  >)
+  set(cxx-is-gcc $<CXX_COMPILER_ID:GNU>)
+  string(CONCAT is-darwin-or-android $<OR:
+    $<PLATFORM_ID:Darwin>,
+    $<PLATFORM_ID:Android>
+  >)
+
   string(CONCAT largefile $<AND:
-    $<OR:
-      $<CXX_COMPILER_ID:GNU>,
-      $<CXX_COMPILER_ID:Clang>,
-      $<CXX_COMPILER_ID:AppleClang>
-    >,
-    $<NOT:
-      $<AND:
-        $<PLATFORM_ID:Darwin>,
-        $<PLATFORM_ID:Android>
-      >
-    >
+    $<OR:${cxx-is-clang},${cxx-is-gcc}>,
+    $<NOT:${is-darwin-or-android}>
   >)
   target_compile_definitions(miniz PRIVATE $<${largefile}:_LARGEFILE64_SOURCE>)
 endif()
@@ -135,15 +138,15 @@ target_include_directories(fossilize
 target_compile_options(fossilize PRIVATE ${FOSSILIZE_CXX_FLAGS})
 target_link_libraries(fossilize
   PRIVATE
-    $<TARGET_NAME_IF_EXISTS:Vulkan::Vulkan>
     Threads::Threads
     $<$<PLATFORM_ID:Android>:android>
     $<$<PLATFORM_ID:Android>:log>
     $<$<PLATFORM_ID:Linux>:rt>
     miniz)
 
-if (CMAKE_VERSION LESS 3.13)
-  set_property(TARGET fossilize APPEND_STRING PROPERTY LINK_FLAGS ${FOSSILIZE_LINK_FLAGS})
+if (CMAKE_VERSION VERSION_LESS 3.13)
+  string(REPLACE ";" " " FOSSILIZE_LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")
+  set_property(TARGET fossilize APPEND_STRING PROPERTY LINK_FLAGS " ${FOSSILIZE_LINK_FLAGS}")
 else()
   target_link_options(fossilize PRIVATE ${FOSSILIZE_LINK_FLAGS})
 endif()

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -7,9 +7,11 @@ add_library(VkLayer_fossilize SHARED
 	dispatch_helper.hpp
 	dispatch_helper.cpp)
 
-target_include_directories(VkLayer_fossilize PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(VkLayer_fossilize
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_compile_options(VkLayer_fossilize PRIVATE ${FOSSILIZE_CXX_FLAGS})
-set_target_properties(VkLayer_fossilize PROPERTIES LINK_FLAGS "${FOSSILIZE_LINK_FLAGS}")
+set_property(TARGET VkLayer_fossilize APPEND_STRING PROPERTY LINK_FLAGS ${FOSSILIZE_LINK_FLAGS})
 install(TARGETS VkLayer_fossilize
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -78,6 +80,11 @@ set_target_properties(VkLayer_fossilize PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELE
 set_target_properties(VkLayer_fossilize PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/layer")
 set_target_properties(VkLayer_fossilize PROPERTIES RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}/layer")
 set_target_properties(VkLayer_fossilize PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/layer")
+set(import-suffix "_imp.lib")
+if (NOT MSVC)
+  set(import-suffix "_imp.dll.a")
+endif()
+set_property(TARGET VkLayer_fossilize PROPERTY IMPORT_SUFFIX ${import-suffix})
 target_link_libraries(VkLayer_fossilize fossilize)
 
 if (ANDROID)


### PR DESCRIPTION
This PR reduces configure time to a decent degree. While generator expressions can be painful to look at in some cases, I tried to keep them simple, minus one area they were needed due to the older version of CMake this project targets. If you're curious to know more about CMake generator expressions, I recommend looking at the documentation for them. That said they are a bit undiscussed but I can easily summarize them as "What if Lisp was bad, had awful syntax, and didn't support spaces in between arguments?".

That's CMake's generator expressions. 

They can also execute in parallel at project generation time so it reduces the amount of time CMake is running at configure time, which is a single threaded operation that executes on an AST, versus the semi-compiled multi-threaded approach project generation can take.

This patch also:

1) Attempts to fix some warnings for newer versions of CMake
2) Uses the `CMAKE_<LANG>_VISIBILITY_PRESET` builtin variable (hence `CMP0063` being set to `NEW`.
3) Permits compiling fossilize under newer versions of C++ and C if used as a subproject
4) Uses the Threads package to use pthreads as possible. This means that Android will still work, but compiler details are not needed
5) Moved most options to the top of the file for folks who don't use CMake GUI or ccmake so they can more easily judge some of the options provided
6) Disable running tests UNLESS `BUILD_TESTING` is on *AND* fossilize is the root project
7) Users can not provide their own miniz library if they would like.
8) Left some notes for further improvements regarding MSVC and sanitizers
9) Fixed an issue with MinGW and import libraries causing filesystem race conditions. This is a temporary fix and more work is needed
10) Use `target_link_options` in the root CMakeLists file when possible. Fall back to setting properties otherwise. This does admittedly need improvement.

A future PR will contain a fossilize_link_options command that properly
sets LINK_OPTIONS when possible, and LINK_FLAGS on pre CMake 3.13
versions.

left a note to eventually tackle the `/Ehsc-` problem with MSVC. I can
handle this later, but it requires some additional work and dependent
projects need a massive improvement as well. Fixing fossilize will not
fix them, and I'd like to tackle them as well. Just because we're using
CMake doesn't mean we *all* have to suffer. (Instead, you can just let
me suffer 🤣)