### PR TITLE
Fix various edge cases with kill()/wait().

### DIFF
--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -137,6 +137,7 @@ public:
 	bool is_process_complete(int *return_status);
 
 	// Requests that process (and its children) are killed.
+	// Can only be used when inherit_process_group is false.
 	bool kill();
 
 	// As the replayer is progressing, it might find SPIR-V modules which might have contributed to a crash.


### PR DESCRIPTION
killpg must only happen after the process group has been created, ensure
ordering here.

Fix waitpid() usage by handling SIGCONT/SIGSTOP signals, which wake
waitpid() up, but we should ignore these signals.