### PR TITLE
Add headers for EXIT_ defines in CLI programs

### DIFF
--- a/cli/fossilize_convert_db.cpp
+++ b/cli/fossilize_convert_db.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 #include "layer/utils.hpp"
+#include <cstdlib>
 
 using namespace Fossilize;
 

--- a/cli/fossilize_merge_db.cpp
+++ b/cli/fossilize_merge_db.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <vector>
 #include "layer/utils.hpp"
+#include <cstdlib>
 
 using namespace Fossilize;
 


### PR DESCRIPTION
The build failed on my Arch machine with gcc 10.1.0 and glibc 2.31. These macros are defined in stdlib.h, so let's include that: https://www.cplusplus.com/reference/cstdlib/