### PR TITLE
Make sure we always use a pipeline cache object.

### DIFF
--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -213,7 +213,6 @@ struct ThreadedReplayer : StateCreatorInterface
 {
 	struct Options
 	{
-		bool pipeline_cache = false;
 		bool spirv_validate = false;
 		bool ignore_derived_pipelines = false;
 		bool pipeline_stats = false;
@@ -428,7 +427,7 @@ struct ThreadedReplayer : StateCreatorInterface
 			vkDestroyPipelineCache(device->get_device(), memory_context_pipeline_cache[index], nullptr);
 		memory_context_pipeline_cache[index] = VK_NULL_HANDLE;
 
-		if (!opts.pipeline_cache)
+		if (!disk_pipeline_cache)
 		{
 			// If we don't have an on-disk pipeline cache, try to limit memory by creating our own pipeline cache,
 			// which is regularly freed and recreated to keep memory usage under control.
@@ -755,7 +754,7 @@ struct ThreadedReplayer : StateCreatorInterface
 				break;
 			}
 
-			VkPipelineCache cache = pipeline_cache;
+			VkPipelineCache cache = disk_pipeline_cache;
 			if (!cache)
 				cache = memory_context_pipeline_cache[work_item.memory_context_index];
 
@@ -779,7 +778,7 @@ struct ThreadedReplayer : StateCreatorInterface
 				feedback.pPipelineStageCreationFeedbacks = feedbacks;
 				feedback.pPipelineCreationFeedback = &primary_feedback;
 
-				if (opts.pipeline_cache && device->pipeline_feedback_enabled())
+				if (disk_pipeline_cache && device->pipeline_feedback_enabled())
 					const_cast<VkGraphicsPipelineCreateInfo *>(work_item.create_info.graphics_create_info)->pNext = &feedback;
 
 				if (vkCreateGraphicsPipelines(device->get_device(), cache, 1, work_item.create_info.graphics_create_info,
@@ -809,7 +808,7 @@ struct ThreadedReplayer : StateCreatorInterface
 					if (opts.control_block && i == 0)
 						opts.control_block->successful_graphics.fetch_add(1, std::memory_order_relaxed);
 
-					if (opts.pipeline_cache && i == 0 && (primary_feedback.flags & VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT) != 0)
+					if (disk_pipeline_cache && i == 0 && (primary_feedback.flags & VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT) != 0)
 					{
 						bool cache_hit = (primary_feedback.flags & VK_PIPELINE_CREATION_FEEDBACK_APPLICATION_PIPELINE_CACHE_HIT_BIT_EXT) != 0;
 
@@ -899,7 +898,7 @@ struct ThreadedReplayer : StateCreatorInterface
 				break;
 			}
 
-			VkPipelineCache cache = pipeline_cache;
+			VkPipelineCache cache = disk_pipeline_cache;
 			if (!cache)
 				cache = memory_context_pipeline_cache[work_item.memory_context_index];
 
@@ -922,7 +921,7 @@ struct ThreadedReplayer : StateCreatorInterface
 				feedback.pPipelineStageCreationFeedbacks = &feedbacks;
 				feedback.pPipelineCreationFeedback = &primary_feedback;
 
-				if (opts.pipeline_cache && device->pipeline_feedback_enabled())
+				if (disk_pipeline_cache && device->pipeline_feedback_enabled())
 					const_cast<VkComputePipelineCreateInfo *>(work_item.create_info.compute_create_info)->pNext = &feedback;
 
 				if (vkCreateComputePipelines(device->get_device(), cache, 1,
@@ -953,7 +952,7 @@ struct ThreadedReplayer : StateCreatorInterface
 					if (opts.control_block && i == 0)
 						opts.control_block->successful_compute.fetch_add(1, std::memory_order_relaxed);
 
-					if (opts.pipeline_cache && i == 0 && (primary_feedback.flags & VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT) != 0)
+					if (disk_pipeline_cache && i == 0 && (primary_feedback.flags & VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT) != 0)
 					{
 						bool cache_hit = (primary_feedback.flags & VK_PIPELINE_CREATION_FEEDBACK_APPLICATION_PIPELINE_CACHE_HIT_BIT_EXT) != 0;
 
@@ -1077,15 +1076,15 @@ struct ThreadedReplayer : StateCreatorInterface
 
 	void flush_pipeline_cache()
 	{
-		if (device && pipeline_cache)
+		if (device && disk_pipeline_cache)
 		{
 			if (!opts.on_disk_pipeline_cache_path.empty())
 			{
 				size_t pipeline_cache_size = 0;
-				if (vkGetPipelineCacheData(device->get_device(), pipeline_cache, &pipeline_cache_size, nullptr) == VK_SUCCESS)
+				if (vkGetPipelineCacheData(device->get_device(), disk_pipeline_cache, &pipeline_cache_size, nullptr) == VK_SUCCESS)
 				{
 					vector<uint8_t> pipeline_buffer(pipeline_cache_size);
-					if (vkGetPipelineCacheData(device->get_device(), pipeline_cache, &pipeline_cache_size, pipeline_buffer.data()) == VK_SUCCESS)
+					if (vkGetPipelineCacheData(device->get_device(), disk_pipeline_cache, &pipeline_cache_size, pipeline_buffer.data()) == VK_SUCCESS)
 					{
 						// This isn't safe to do in a signal handler, but it's unlikely to be a problem in practice.
 						FILE *file = fopen(opts.on_disk_pipeline_cache_path.c_str(), "wb");
@@ -1096,8 +1095,8 @@ struct ThreadedReplayer : StateCreatorInterface
 					}
 				}
 			}
-			vkDestroyPipelineCache(device->get_device(), pipeline_cache, nullptr);
-			pipeline_cache = VK_NULL_HANDLE;
+			vkDestroyPipelineCache(device->get_device(), disk_pipeline_cache, nullptr);
+			disk_pipeline_cache = VK_NULL_HANDLE;
 		}
 	}
 
@@ -1286,47 +1285,44 @@ struct ThreadedReplayer : StateCreatorInterface
 				}
 			}
 
-			if (opts.pipeline_cache)
+			if (!opts.on_disk_pipeline_cache_path.empty())
 			{
 				VkPipelineCacheCreateInfo info = { VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
 				vector<uint8_t> on_disk_cache;
 
 				// Try to load on-disk cache.
-				if (!opts.on_disk_pipeline_cache_path.empty())
+				FILE *file = fopen(opts.on_disk_pipeline_cache_path.c_str(), "rb");
+				if (file)
 				{
-					FILE *file = fopen(opts.on_disk_pipeline_cache_path.c_str(), "rb");
-					if (file)
-					{
-						fseek(file, 0, SEEK_END);
-						size_t len = ftell(file);
-						rewind(file);
+					fseek(file, 0, SEEK_END);
+					size_t len = ftell(file);
+					rewind(file);
 
-						if (len != 0)
+					if (len != 0)
+					{
+						on_disk_cache.resize(len);
+						if (fread(on_disk_cache.data(), 1, len, file) == len)
 						{
-							on_disk_cache.resize(len);
-							if (fread(on_disk_cache.data(), 1, len, file) == len)
+							if (validate_pipeline_cache_header(on_disk_cache))
 							{
-								if (validate_pipeline_cache_header(on_disk_cache))
-								{
-									info.pInitialData = on_disk_cache.data();
-									info.initialDataSize = on_disk_cache.size();
-								}
-								else
-									LOGI("Failed to validate pipeline cache. Creating a blank one.\n");
+								info.pInitialData = on_disk_cache.data();
+								info.initialDataSize = on_disk_cache.size();
 							}
+							else
+								LOGI("Failed to validate pipeline cache. Creating a blank one.\n");
 						}
 					}
 				}
 
-				if (vkCreatePipelineCache(device->get_device(), &info, nullptr, &pipeline_cache) != VK_SUCCESS)
+				if (vkCreatePipelineCache(device->get_device(), &info, nullptr, &disk_pipeline_cache) != VK_SUCCESS)
 				{
 					LOGE("Failed to create pipeline cache, trying to create a blank one.\n");
 					info.initialDataSize = 0;
 					info.pInitialData = nullptr;
-					if (vkCreatePipelineCache(device->get_device(), &info, nullptr, &pipeline_cache) != VK_SUCCESS)
+					if (vkCreatePipelineCache(device->get_device(), &info, nullptr, &disk_pipeline_cache) != VK_SUCCESS)
 					{
 						LOGE("Failed to create pipeline cache.\n");
-						pipeline_cache = VK_NULL_HANDLE;
+						disk_pipeline_cache = VK_NULL_HANDLE;
 					}
 				}
 			}
@@ -2219,7 +2215,7 @@ struct ThreadedReplayer : StateCreatorInterface
 	std::unordered_set<Hash> masked_shader_modules;
 	std::unordered_map<VkShaderModule, Hash> shader_module_to_hash;
 	std::unordered_set<VkShaderModule> enqueued_shader_modules;
-	VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
+	VkPipelineCache disk_pipeline_cache = VK_NULL_HANDLE;
 	VkValidationCacheEXT validation_cache = VK_NULL_HANDLE;
 
 	// VALVE: multi-threaded work queue for replayer
@@ -2336,7 +2332,6 @@ static void print_help()
 	     "\t[--device-index <index>]\n"
 	     "\t[--enable-validation]\n"
 	     "\t[--enable-pipeline-stats <path>]\n"
-	     "\t[--pipeline-cache]\n"
 	     "\t[--spirv-val]\n"
 	     "\t[--num-threads <count>]\n"
 	     "\t[--loop <count>]\n"
@@ -2474,7 +2469,6 @@ static int run_progress_process(const VulkanDevice::Options &device_opts,
 	                                    nullptr : replayer_opts.on_disk_validation_blacklist_path.c_str();
 	opts.pipeline_stats_path = replayer_opts.pipeline_stats_path.empty() ?
 	                           nullptr : replayer_opts.pipeline_stats_path.c_str();
-	opts.pipeline_cache = replayer_opts.pipeline_cache;
 	opts.num_threads = replayer_opts.num_threads;
 	opts.quiet = true;
 	opts.databases = databases.data();
@@ -3001,7 +2995,7 @@ static int run_normal_process(ThreadedReplayer &replayer, const vector<const cha
 	LOGI("Opening archive took %ld ms:\n", elapsed_ms_read_archive);
 	LOGI("Parsing archive took %ld ms:\n", elapsed_ms_prepare);
 
-	if (replayer.opts.pipeline_cache && replayer.device->pipeline_feedback_enabled())
+	if (!replayer.opts.on_disk_pipeline_cache_path.empty() && replayer.device->pipeline_feedback_enabled())
 	{
 		LOGI("Pipeline cache hits reported: %u\n", replayer.pipeline_cache_hits.load());
 		LOGI("Pipeline cache misses reported: %u\n", replayer.pipeline_cache_misses.load());
@@ -3082,7 +3076,6 @@ int main(int argc, char *argv[])
 	cbs.add("--help", [](CLIParser &parser) { print_help(); parser.end(); });
 	cbs.add("--device-index", [&](CLIParser &parser) { opts.device_index = parser.next_uint(); });
 	cbs.add("--enable-validation", [&](CLIParser &) { opts.enable_validation = true; });
-	cbs.add("--pipeline-cache", [&](CLIParser &) { replayer_opts.pipeline_cache = true; });
 	cbs.add("--spirv-val", [&](CLIParser &) { replayer_opts.spirv_validate = true; });
 	cbs.add("--on-disk-pipeline-cache", [&](CLIParser &parser) { replayer_opts.on_disk_pipeline_cache_path = parser.next_string(); });
 	cbs.add("--on-disk-validation-cache", [&](CLIParser &parser) {
@@ -3180,9 +3173,6 @@ int main(int argc, char *argv[])
 
 	if (replayer_opts.num_threads < 1)
 		replayer_opts.num_threads = 1;
-
-	if (!replayer_opts.on_disk_pipeline_cache_path.empty())
-		replayer_opts.pipeline_cache = true;
 #endif
 
 	if (!replayer_opts.pipeline_stats_path.empty())

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -405,8 +405,6 @@ bool ProcessProgress::start_child_process()
 		cmdline += Global::shm_mutex_name;
 	}
 
-	if (Global::base_replayer_options.pipeline_cache)
-		cmdline += " --pipeline-cache";
 	if (Global::base_replayer_options.spirv_validate)
 		cmdline += " --spirv-val";
 	if (Global::device_options.null_device)

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -80,9 +80,6 @@ public:
 		unsigned end_compute_index;
 		bool use_pipeline_range;
 
-		// Maps to --pipeline-cache
-		bool pipeline_cache;
-
 		// Redirect stdout and stderr to /dev/null or NUL.
 		bool quiet;
 

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -369,8 +369,6 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	argv.push_back("--shmem-fd");
 	argv.push_back(fd_name);
 
-	if (options.pipeline_cache)
-		argv.push_back("--pipeline-cache");
 	if (options.spirv_validate)
 		argv.push_back("--spirv-val");
 

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -444,8 +444,6 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	cmdline += " --shm-mutex-name ";
 	cmdline += shm_mutex_name;
 
-	if (options.pipeline_cache)
-		cmdline += " --pipeline-cache";
 	if (options.spirv_validate)
 		cmdline += " --spirv-val";
 


### PR DESCRIPTION
Avoids memory explosion inside certain drivers where they employ
internal caches which grow in an unbounded fashion.