### PR TITLE
Add support for implicit whitelist

### DIFF
--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -480,6 +480,12 @@ bool ProcessProgress::start_child_process()
 		cmdline += std::to_string(Global::base_replayer_options.timeout_seconds);
 	}
 
+	for (unsigned whitelist_index : Global::base_replayer_options.implicit_whitelist_database_indices)
+	{
+		cmdline += " --implicit-whitelist ";
+		cmdline += std::to_string(whitelist_index);
+	}
+
 	// Create custom named pipes which can be inherited by our child processes.
 	SECURITY_ATTRIBUTES attrs = {};
 	attrs.bInheritHandle = TRUE;

--- a/fossilize_db.cpp
+++ b/fossilize_db.cpp
@@ -87,6 +87,16 @@ DatabaseInterface::DatabaseInterface(DatabaseMode mode)
 	impl->mode = mode;
 }
 
+bool DatabaseInterface::has_sub_databases()
+{
+	return false;
+}
+
+DatabaseInterface *DatabaseInterface::get_sub_database(unsigned)
+{
+	return nullptr;
+}
+
 bool DatabaseInterface::load_whitelist_database(const char *path)
 {
 	if (impl->mode != DatabaseMode::ReadOnly)
@@ -1367,6 +1377,24 @@ struct ConcurrentDatabase : DatabaseInterface
 		}
 
 		return nullptr;
+	}
+
+	DatabaseInterface *get_sub_database(unsigned index) override
+	{
+		if (mode != DatabaseMode::ReadOnly)
+			return nullptr;
+
+		if (index == 0)
+			return readonly_interface.get();
+		else if (index <= extra_readonly.size())
+			return extra_readonly[index - 1].get();
+		else
+			return nullptr;
+	}
+
+	bool has_sub_databases() override
+	{
+		return true;
 	}
 
 	std::string base_path;

--- a/fossilize_db.cpp
+++ b/fossilize_db.cpp
@@ -1362,7 +1362,7 @@ struct ConcurrentDatabase : DatabaseInterface
 
 		for (auto &extra : extra_readonly)
 		{
-			if (extra->has_entry(tag, hash))
+			if (extra && extra->has_entry(tag, hash))
 				return extra->get_db_path_for_hash(tag, hash);
 		}
 

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -99,7 +99,7 @@ public:
 
 	// Useful if also replaying a database which is known to contain valid data.
 	//
-	// Only supported for the concurrent database.
+	// Currently only supported for the concurrent database.
 	// This must be called before prepare().
 	// Can only be used for ReadOnly database mode.
 	//

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -135,6 +135,15 @@ public:
 
 	virtual const char *get_db_path_for_hash(ResourceTag tag, Hash hash) = 0;
 
+	// For the concurrent database, gets the sub-database, otherwise returns nullptr.
+	// Index 0 refers to the primary read-only database,
+	// and index 1 and up refer to extra readonly databases which are passed in.
+	// The sub-database is not subject to white- or blacklisting.
+	// This can only be used in read-only mode.
+	// For non-concurrent database types, index 0 returns this, nullptr otherwise.
+	virtual DatabaseInterface *get_sub_database(unsigned index);
+	virtual bool has_sub_databases();
+
 protected:
 	bool test_resource_filter(ResourceTag tag, Hash hash) const;
 	bool add_to_implicit_whitelist(DatabaseInterface &iface);

--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -97,6 +97,20 @@ public:
 	bool load_whitelist_database(const char *path);
 	bool load_blacklist_database(const char *path);
 
+	// Useful if also replaying a database which is known to contain valid data.
+	//
+	// Only supported for the concurrent database.
+	// This must be called before prepare().
+	// Can only be used for ReadOnly database mode.
+	//
+	// In this mode, any resource in the denoted database will always pass the whitelist test.
+	// Index 0 refers to the primary read-only database,
+	// and index 1 and up refer to extra readonly databases which are passed in.
+	//
+	// Can be called multiple times to whitelist multiple databases.
+	// Using this is meaningless unless load_whitelist_database is also used.
+	void promote_sub_database_to_whitelist(unsigned index);
+
 	// Prepares the database. It can load in the off-line archive from disk.
 	virtual bool prepare() = 0;
 
@@ -123,6 +137,7 @@ public:
 
 protected:
 	bool test_resource_filter(ResourceTag tag, Hash hash) const;
+	bool add_to_implicit_whitelist(DatabaseInterface &iface);
 	struct Impl;
 	Impl *impl;
 };

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -52,6 +52,13 @@ public:
 		const char * const *databases;
 		unsigned num_databases;
 
+		// Represents indices into databases array.
+		// All blobs in a selected database are marked as being implicitly whitelisted,
+		// and extra validation steps are avoided.
+		// Is only meaningful if used along on_disk_validation_whitelist.
+		const unsigned *implicit_whitelist_indices;
+		unsigned num_implicit_whitelist_indices;
+
 		// Path to an on-disk pipeline cache. Maps to --on-disk-pipeline-cache.
 		const char *on_disk_pipeline_cache;
 

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -34,6 +34,7 @@
 #include "layer/utils.hpp"
 #include <atomic>
 #include <vector>
+#include <array>
 #include <unordered_set>
 #include <string>
 #include <signal.h>
@@ -493,6 +494,15 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 		argv.push_back("--timeout-seconds");
 		sprintf(timeout, "%u", options.timeout_seconds);
 		argv.push_back(timeout);
+	}
+
+	std::vector<std::array<char, 16>> implicit_indices;
+	implicit_indices.resize(options.num_implicit_whitelist_indices);
+	for (unsigned i = 0; i < options.num_implicit_whitelist_indices; i++)
+	{
+		argv.push_back("--implicit-whitelist");
+		sprintf(implicit_indices[i].data(), "%u", options.implicit_whitelist_indices[i]);
+		argv.push_back(implicit_indices[i].data());
 	}
 
 	argv.push_back(nullptr);

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -531,6 +531,12 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		cmdline += std::to_string(options.timeout_seconds);
 	}
 
+	for (unsigned i = 0; i < options.num_implicit_whitelist_indices; i++)
+	{
+		cmdline += " --implicit-whitelist ";
+		cmdline += std::to_string(options.implicit_whitelist_indices[i]);
+	}
+
 	STARTUPINFO si = {};
 	si.cb = sizeof(STARTUPINFO);
 	si.dwFlags = STARTF_USESTDHANDLES;

--- a/test/fossilize_test.cpp
+++ b/test/fossilize_test.cpp
@@ -984,6 +984,14 @@ static bool test_implicit_whitelist()
 			return false;
 		if (!db2->write_entry(RESOURCE_COMPUTE_PIPELINE, 4, blob, sizeof(blob), PAYLOAD_WRITE_NO_FLAGS))
 			return false;
+
+		// Should not return a database for Append mode.
+		if (db0->get_sub_database(0))
+			return false;
+		if (db1->get_sub_database(0))
+			return false;
+		if (db2->get_sub_database(0))
+			return false;
 	}
 
 	static const char *extra_paths[] = {
@@ -1036,6 +1044,18 @@ static bool test_implicit_whitelist()
 	if (hashes[0] != 3)
 		return false;
 	if (hashes[1] != 4)
+		return false;
+
+	// We have no primary database.
+	if (replay_db->get_sub_database(0))
+		return false;
+	if (!replay_db->get_sub_database(1))
+		return false;
+	if (!replay_db->get_sub_database(2))
+		return false;
+	if (!replay_db->get_sub_database(3))
+		return false;
+	if (replay_db->get_sub_database(4))
 		return false;
 
 	replay_db.reset();


### PR DESCRIPTION
Allows replayer and database APIs to mark certain databases as being implicitly whitelisted. Useful when it is known that certain databases come from a trusted source.