### PR TITLE
Implement a replayer cache.

### DIFF
--- a/cli/device.cpp
+++ b/cli/device.cpp
@@ -218,7 +218,6 @@ bool VulkanDevice::init_device(const Options &opts)
 
 	for (uint32_t i = 0; i < gpu_count; i++)
 	{
-		VkPhysicalDeviceProperties gpu_props = {};
 		vkGetPhysicalDeviceProperties(gpus[i], &gpu_props);
 		LOGI("Enumerated GPU #%u:\n", i);
 		LOGI("  name: %s\n", gpu_props.deviceName);
@@ -241,7 +240,6 @@ bool VulkanDevice::init_device(const Options &opts)
 	else
 		gpu = gpus.front();
 
-	VkPhysicalDeviceProperties gpu_props = {};
 	vkGetPhysicalDeviceProperties(gpu, &gpu_props);
 	LOGI("Chose GPU:\n");
 	LOGI("  name: %s\n", gpu_props.deviceName);

--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -90,11 +90,17 @@ public:
 		return feature_filter;
 	}
 
+	const VkPhysicalDeviceProperties &get_gpu_properties() const
+	{
+		return gpu_props;
+	}
+
 private:
 	VkInstance instance = VK_NULL_HANDLE;
 	VkPhysicalDevice gpu = VK_NULL_HANDLE;
 	VkDevice device = VK_NULL_HANDLE;
 	VkDebugReportCallbackEXT callback = VK_NULL_HANDLE;
+	VkPhysicalDeviceProperties gpu_props = {};
 	uint32_t api_version = 0;
 
 	void (*validation_callback)(void *) = nullptr;

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -486,6 +486,14 @@ bool ProcessProgress::start_child_process()
 		cmdline += std::to_string(whitelist_index);
 	}
 
+	if (!Global::base_replayer_options.replayer_cache_path.empty())
+	{
+		cmdline += " --replayer-cache ";
+		cmdline += "\"";
+		cmdline += Global::base_replayer_options.replayer_cache_path;
+		cmdline += "\"";
+	}
+
 	// Create custom named pipes which can be inherited by our child processes.
 	SECURITY_ATTRIBUTES attrs = {};
 	attrs.bInheritHandle = TRUE;

--- a/fossilize_external_replayer.cpp
+++ b/fossilize_external_replayer.cpp
@@ -84,10 +84,10 @@ void ExternalReplayer::compute_condensed_progress(const Progress &progress, unsi
 	// Just clamp it to never report obviously wrong values.
 	// The only glitch we risk is that we're stuck at "100%" a bit longer,
 	// but UI can always report something here when we know we're not done yet.
-	unsigned parsed_graphics = (std::min)(progress.graphics.parsed + progress.graphics.parsed_fail, progress.total_graphics_pipeline_blobs);
-	unsigned parsed_compute = (std::min)(progress.compute.parsed + progress.compute.parsed_fail, progress.total_compute_pipeline_blobs);
-	unsigned compiled_graphics = (std::min)(progress.graphics.completed + progress.graphics.skipped, progress.total_graphics_pipeline_blobs);
-	unsigned compiled_compute = (std::min)(progress.compute.completed + progress.compute.skipped, progress.total_compute_pipeline_blobs);
+	unsigned parsed_graphics = (std::min)(progress.graphics.parsed + progress.graphics.parsed_fail + progress.graphics.cached, progress.total_graphics_pipeline_blobs);
+	unsigned parsed_compute = (std::min)(progress.compute.parsed + progress.compute.parsed_fail + progress.compute.cached, progress.total_compute_pipeline_blobs);
+	unsigned compiled_graphics = (std::min)(progress.graphics.completed + progress.graphics.skipped + progress.graphics.cached, progress.total_graphics_pipeline_blobs);
+	unsigned compiled_compute = (std::min)(progress.compute.completed + progress.compute.skipped + progress.compute.cached, progress.total_compute_pipeline_blobs);
 	unsigned decompressed_modules = (std::min)(progress.completed_modules + progress.module_validation_failures +
 	                                           progress.banned_modules + progress.missing_modules, progress.total_modules);
 

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -72,6 +72,11 @@ public:
 		// Path to store pipeline stats in.
 		const char *pipeline_stats_path;
 
+		// Path to a replayer cache.
+		// path.$pipelineCacheUUID.*.foz will be written and any pipelines in
+		// path.$pipelineCacheUUID.foz will be skipped.
+		const char *replayer_cache_path;
+
 		// Extra environment variables which will be added to the child process tree.
 		// Will not modify environment of caller.
 		const Environment *environment_variables;
@@ -175,6 +180,7 @@ public:
 		uint32_t parsed_fail;
 		uint32_t completed;
 		uint32_t skipped;
+		uint32_t cached;
 
 		// This value is dynamic and will be incremented as pipelines are queued up for parsing.
 		uint32_t total;

--- a/fossilize_external_replayer_control_block.hpp
+++ b/fossilize_external_replayer_control_block.hpp
@@ -32,7 +32,7 @@ static_assert(sizeof(std::atomic<uint32_t>) == sizeof(uint32_t), "Atomic size mi
 namespace Fossilize
 {
 enum { ControlBlockMessageSize = 64 };
-enum { ControlBlockMagic = 0x19bcde17 };
+enum { ControlBlockMagic = 0x19bcde18 };
 
 struct SharedControlBlock
 {
@@ -47,6 +47,8 @@ struct SharedControlBlock
 	std::atomic<uint32_t> successful_compute;
 	std::atomic<uint32_t> skipped_graphics;
 	std::atomic<uint32_t> skipped_compute;
+	std::atomic<uint32_t> cached_graphics;
+	std::atomic<uint32_t> cached_compute;
 	std::atomic<uint32_t> clean_process_deaths;
 	std::atomic<uint32_t> dirty_process_deaths;
 	std::atomic<uint32_t> parsed_graphics;

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -157,11 +157,13 @@ ExternalReplayer::PollResult ExternalReplayer::Impl::poll_progress(ExternalRepla
 	progress.compute.parsed = shm_block->parsed_compute.load(std::memory_order_relaxed);
 	progress.compute.parsed_fail = shm_block->parsed_compute_failures.load(std::memory_order_relaxed);
 	progress.compute.skipped = shm_block->skipped_compute.load(std::memory_order_relaxed);
+	progress.compute.cached = shm_block->cached_compute.load(std::memory_order_relaxed);
 	progress.compute.completed = shm_block->successful_compute.load(std::memory_order_relaxed);
 	progress.graphics.total = shm_block->total_graphics.load(std::memory_order_relaxed);
 	progress.graphics.parsed = shm_block->parsed_graphics.load(std::memory_order_relaxed);
 	progress.graphics.parsed_fail = shm_block->parsed_graphics_failures.load(std::memory_order_relaxed);
 	progress.graphics.skipped = shm_block->skipped_graphics.load(std::memory_order_relaxed);
+	progress.graphics.cached = shm_block->cached_graphics.load(std::memory_order_relaxed);
 	progress.graphics.completed = shm_block->successful_graphics.load(std::memory_order_relaxed);
 	progress.completed_modules = shm_block->successful_modules.load(std::memory_order_relaxed);
 	progress.missing_modules = shm_block->parsed_module_failures.load(std::memory_order_relaxed);
@@ -454,6 +456,12 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	{
 		argv.push_back("--on-disk-validation-blacklist");
 		argv.push_back(options.on_disk_validation_blacklist);
+	}
+
+	if (options.replayer_cache_path)
+	{
+		argv.push_back("--replayer-cache");
+		argv.push_back(options.replayer_cache_path);
 	}
 
 	if (options.enable_validation)

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -106,11 +106,13 @@ ExternalReplayer::PollResult ExternalReplayer::Impl::poll_progress(ExternalRepla
 	progress.compute.parsed = shm_block->parsed_compute.load(std::memory_order_relaxed);
 	progress.compute.parsed_fail = shm_block->parsed_compute_failures.load(std::memory_order_relaxed);
 	progress.compute.skipped = shm_block->skipped_compute.load(std::memory_order_relaxed);
+	progress.compute.cached = shm_block->cached_compute.load(std::memory_order_relaxed);
 	progress.compute.completed = shm_block->successful_compute.load(std::memory_order_relaxed);
 	progress.graphics.total = shm_block->total_graphics.load(std::memory_order_relaxed);
 	progress.graphics.parsed = shm_block->parsed_graphics.load(std::memory_order_relaxed);
 	progress.graphics.parsed_fail = shm_block->parsed_graphics_failures.load(std::memory_order_relaxed);
 	progress.graphics.skipped = shm_block->skipped_graphics.load(std::memory_order_relaxed);
+	progress.graphics.cached = shm_block->cached_graphics.load(std::memory_order_relaxed);
 	progress.graphics.completed = shm_block->successful_graphics.load(std::memory_order_relaxed);
 	progress.completed_modules = shm_block->successful_modules.load(std::memory_order_relaxed);
 	progress.missing_modules = shm_block->parsed_module_failures.load(std::memory_order_relaxed);
@@ -489,6 +491,14 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		cmdline += " --on-disk-validation-blacklist ";
 		cmdline += "\"";
 		cmdline += options.on_disk_validation_blacklist;
+		cmdline += "\"";
+	}
+
+	if (options.replayer_cache_path)
+	{
+		cmdline += " --replayer-cache ";
+		cmdline += "\"";
+		cmdline += options.replayer_cache_path;
 		cmdline += "\"";
 	}
 


### PR DESCRIPTION
Allows us to cache which pipelines have been replayed, and skip them on
subsequent runs as long as the pipelineCacheUUID stays the same.