### PR TITLE
Autogroup batch scheduling

### DIFF
--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -27,6 +27,7 @@
 #include <sys/wait.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,6 +47,10 @@
 #include "platform/futex_wrapper_linux.hpp"
 #else
 #include "platform/gcc_clang_spinlock.hpp"
+#endif
+
+#ifndef SCHED_BATCH
+#define SCHED_BATCH 3
 #endif
 
 namespace Fossilize
@@ -538,6 +543,18 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	nice(19);
 	if (errno != 0)
 		LOGE("Failed to set nice value for external replayer!\n");
+
+	// Replayer crunches a lot of numbers, hint the scheduler.
+	// This results in better throughput at the same or lower CPU usage (due
+	// to better CPU cache utilization with bigger time slices), it doesn't
+	// preempt interactive tasks (less impact on games), and it also makes a
+	// better chance for the block layer to coalesce IO requests (more IO
+	// may be dispatched per time slice).
+	{
+		struct sched_param p = { .sched_priority = 0 };
+		if (sched_setscheduler(0, SCHED_BATCH, &p) < 0)
+			LOGI("Failed to set scheduling policy for external replayer!\n");
+	}
 
 	// We're now in the child process, so it's safe to override environment here.
 	for (unsigned i = 0; i < options.num_environment_variables; i++)

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -544,6 +544,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	if (errno != 0)
 		LOGE("Failed to set nice value for external replayer!\n");
 
+#ifdef __linux__
 	// Replayer crunches a lot of numbers, hint the scheduler.
 	// This results in better throughput at the same or lower CPU usage (due
 	// to better CPU cache utilization with bigger time slices), it doesn't
@@ -555,6 +556,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 		if (sched_setscheduler(0, SCHED_BATCH, &p) < 0)
 			LOGE("Failed to set scheduling policy for external replayer!\n");
 	}
+#endif
 
 	// We're now in the child process, so it's safe to override environment here.
 	for (unsigned i = 0; i < options.num_environment_variables; i++)
@@ -593,6 +595,7 @@ static bool create_low_priority_autogroup()
 		return false;
 	}
 
+#ifdef __linux__
 	bool autogroups_enabled = false;
 	{
 		FILE *file = fopen("/proc/sys/kernel/sched_autogroup_enabled", "rb");
@@ -623,6 +626,7 @@ static bool create_low_priority_autogroup()
 	}
 	else
 		LOGI("Autogroup scheduling is not enabled on this kernel. Will rely entirely on nice().\n");
+#endif
 
 	return true;
 }

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -551,9 +551,9 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	// better chance for the block layer to coalesce IO requests (more IO
 	// may be dispatched per time slice).
 	{
-		struct sched_param p = { .sched_priority = 0 };
+		struct sched_param p = {};
 		if (sched_setscheduler(0, SCHED_BATCH, &p) < 0)
-			LOGI("Failed to set scheduling policy for external replayer!\n");
+			LOGE("Failed to set scheduling policy for external replayer!\n");
 	}
 
 	// We're now in the child process, so it's safe to override environment here.


### PR DESCRIPTION
Improves the CPU scheduling situation on Linux.

Pulls in @kakra 's SCHED_BATCH enablement. Also, rather than use a setpgrp, use setsid to create a new session, which creates a new prgroup + makes a new autogroup for scheduling. This is apparently not strictly needed for purposes of SCHED_BATCH, but cannot hurt.

See discussion in #99.