### PR TITLE
Rewrite how archives are parsed in a multi-process environment.

### DIFF
--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -392,7 +392,7 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	char shm_mutex_name[256];
 	sprintf(shm_name, "fossilize-external-%lu-%d", GetCurrentProcessId(), shm_index.fetch_add(1, std::memory_order_relaxed));
 	sprintf(shm_mutex_name, "fossilize-external-%lu-%d", GetCurrentProcessId(), shm_index.fetch_add(1, std::memory_order_relaxed));
-	mapping_handle = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, (DWORD)shm_block_size, shm_name);
+	mapping_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, (DWORD)shm_block_size, shm_name);
 
 	if (!mapping_handle)
 	{


### PR DESCRIPTION
In order to stave off memory pressure and disk thrashing, we will parse
the archive once, and encode the resulting metadata in a shared memory
block. This metadata block can then be imported in child processes where
we avoid having to scan through the archive altogether. This saves a lot
of startup churn, and for very large archives + many processes, we save
a significant amount of memory as well, as essentially the same
duplicated information would be placed in memory.