### PR TITLE
Linux: Add nicer memory logging for --progress.

### DIFF
--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -595,7 +595,9 @@ static int run_master_process(const VulkanDevice::Options &opts,
 		int ret = epoll_wait(Global::epoll_fd, events, 64, -1);
 		if (ret < 0)
 		{
-			LOGE("epoll_wait() failed.\n");
+			if (errno == EINTR)
+				continue;
+			LOGE("epoll_wait() failed (errno = %d).\n", errno);
 			return EXIT_FAILURE;
 		}
 

--- a/fossilize_external_replayer.cpp
+++ b/fossilize_external_replayer.cpp
@@ -124,4 +124,9 @@ bool ExternalReplayer::get_compute_failed_validation(size_t *num_hashes, Hash *h
 {
 	return impl->get_compute_failed_validation(num_hashes, hashes);
 }
+
+bool ExternalReplayer::poll_memory_usage(uint32_t *num_processes, ProcessStats *stats) const
+{
+	return impl->poll_memory_usage(num_processes, stats);
+}
 }

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -208,6 +208,32 @@ public:
 	PollResult poll_progress(Progress &progress);
 	static void compute_condensed_progress(const Progress &progress, unsigned &completed, unsigned &total);
 
+	struct ProcessStats
+	{
+		// Maps to RSS in Linux (element 1 in statm). Measured in MiB.
+		uint32_t resident_mib;
+		// Maps to Resident shared (element 2 in statm) in Linux. Measured in MiB.
+		uint32_t shared_mib;
+
+		// Set to how much shared metadata this process maps.
+		// This can be subtracted from shared_mib to figure out
+		// how much unrelated shared memory is used.
+		uint32_t shared_metadata_mib;
+
+		// resident - shared is the amount of resident memory which is unique to the process,
+	};
+
+	// num_processes must not be nullptr.
+	// If stats is non-nullptr, num_processes will receive the actual number of values that were reported in stats.
+	// Since number of child processes is technically volatile, the number of child processes can change
+	// between a call to poll_memory_usage(&count, nullptr) and poll_memory_usage(&count, stats).
+	// *num_processes is the upper bound when called with stats.
+	// This returns false if platform does not yet support memory query.
+	// If memory query is not available yet, 0 process stats will be returned.
+	// The internal data is updated at some regular interval.
+	// The first process is the primary replaying process.
+	bool poll_memory_usage(uint32_t *num_processes, ProcessStats *stats) const;
+
 private:
 	struct Impl;
 	Impl *impl;

--- a/fossilize_external_replayer_control_block.hpp
+++ b/fossilize_external_replayer_control_block.hpp
@@ -32,7 +32,8 @@ static_assert(sizeof(std::atomic<uint32_t>) == sizeof(uint32_t), "Atomic size mi
 namespace Fossilize
 {
 enum { ControlBlockMessageSize = 64 };
-enum { ControlBlockMagic = 0x19bcde18 };
+enum { ControlBlockMagic = 0x19bcde19 };
+enum { MaxProcessStats = 256 };
 
 struct SharedControlBlock
 {
@@ -66,6 +67,13 @@ struct SharedControlBlock
 
 	std::atomic<uint32_t> static_total_count_graphics;
 	std::atomic<uint32_t> static_total_count_compute;
+
+	std::atomic<uint32_t> num_processes_memory_stats;
+	std::atomic<uint32_t> metadata_shared_size_mib;
+	// Could be 64-bit, but we can express up to ~4 * 10^15 bytes this way.
+	// 64-bit would need some form of locking on 32-bit arch.
+	std::atomic<uint32_t> process_reserved_memory_mib[MaxProcessStats];
+	std::atomic<uint32_t> process_shared_memory_mib[MaxProcessStats];
 
 	// Ring buffer. Needs lock.
 	uint32_t write_count;

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -71,6 +71,7 @@ struct ExternalReplayer::Impl
 	bool get_failed(const std::unordered_set<Hash> &failed, size_t *count, Hash *hashes) const;
 	bool get_failed(const std::vector<std::pair<unsigned, Hash>> &failed, size_t *count,
 	                unsigned *indices, Hash *hashes) const;
+	bool poll_memory_usage(uint32_t *num_processes, ProcessStats *stats) const;
 };
 
 ExternalReplayer::Impl::~Impl()
@@ -85,6 +86,11 @@ ExternalReplayer::Impl::~Impl()
 		CloseHandle(process);
 	if (job_handle)
 		CloseHandle(job_handle);
+}
+
+bool ExternalReplayer::Impl::poll_memory_usage(uint32_t *, ProcessStats *) const
+{
+	return false;
 }
 
 uintptr_t ExternalReplayer::Impl::get_process_handle() const


### PR DESCRIPTION
Reports memory usage for all child processes as well, making it easier
to study what is going on.