### PR TITLE
Fix some process leaks.

### DIFF
--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -435,6 +435,8 @@ bool ProcessProgress::start_child_process()
 		close(Global::timer_fd);
 		close(crash_fds[0]);
 		close(input_fds[1]);
+		if (Global::control_fd >= 0)
+			close(Global::control_fd);
 
 		// Override stdin/stdout.
 		if (dup2(crash_fds[1], STDOUT_FILENO) < 0)

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -418,7 +418,7 @@ bool ExternalReplayer::Impl::kill()
 		kill_fd = -1;
 	}
 
-	bool ret = killpg(pid, SIGTERM) == 0;
+	bool ret = killpg(pid, SIGKILL) == 0;
 	if (!ret)
 		LOGI("ExternalReplayer::Impl::kill(): Failed to kill: errno %d.\n", errno);
 	return ret;
@@ -816,7 +816,7 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 		return false;
 
 	int control_fds[2] = { -1, -1 };
-	if (socketpair(AF_UNIX, SOCK_DGRAM, 0, control_fds) < 0)
+	if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, control_fds) < 0)
 		return false;
 
 	pid_t new_pid = fork();


### PR DESCRIPTION
- Need to use SIGKILL to ensure that stopped child processes actually
  die. The replayer handled this correctly, but not the external
  replayer API.
- Need to use SEQPACKET socket type to actually be able to detect
  hangups. socketpair() DGRAMs apparently don't work even if they are
  connected ...

Fix #129.