### PR TITLE
Add support for bucket system in extra_read_only_archives

### DIFF
--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -260,6 +260,13 @@ bool merge_concurrent_databases(const char *append_database_path, const char * c
 // to update last access time,
 // which lets external tools deduce which buckets are actually in use by the application in question.
 //
-// extra_read_only_database_paths are not modified by buckets, but the usefulness of extra_read_only archives
-// in append mode is somewhat questionable to begin with.
+// extra_read_only_database_paths are not modified by buckets directly,
+// but to make the system work well with buckets, it is possible to encode a relative path
+// to the basedir of the read-only part of the bucket as, e.g.:
+// "$bucketdir/static_archive.foz"
+// The relative path is always honored, even if bucket paths are not enabled.
+// If the selected read-only path is e.g.:
+// $base_path.$bucket_dirname/$bucket_basename.foz
+// the resulting path for the extra read only archive is:
+// $base_path.$bucket_dirname/static_archive.foz
 }

--- a/test/fossilize_test.cpp
+++ b/test/fossilize_test.cpp
@@ -1105,7 +1105,8 @@ static bool test_concurrent_database_bucket_write()
 {
 	{
 		auto db = std::unique_ptr<DatabaseInterface>(create_concurrent_database(".__test_concurrent",
-		                                                                         DatabaseMode::Append, nullptr, 0));
+		                                                                        DatabaseMode::Append,
+		                                                                        nullptr, 0));
 		if (!db->set_bucket_path("buck", "base"))
 			return false;
 		if (!db->prepare())
@@ -1132,6 +1133,71 @@ static bool test_concurrent_database_bucket_write()
 
 	remove(".__test_concurrent.buck/TOUCH");
 	remove(".__test_concurrent.buck/base.1.foz");
+	remove(".__test_concurrent.buck");
+	return true;
+}
+
+static bool test_concurrent_database_bucket_extra_paths()
+{
+	{
+		auto db = std::unique_ptr<DatabaseInterface>(create_concurrent_database(
+				".__test_concurrent", DatabaseMode::Append,
+				nullptr, 0));
+		if (!db->set_bucket_path("buck", "base"))
+			return false;
+		if (!db->prepare())
+			return false;
+
+		const uint8_t blob[] = { 1, 2, 3 };
+		if (!db->write_entry(RESOURCE_SHADER_MODULE, 100, blob, sizeof(blob), 0))
+			return false;
+	}
+
+	{
+		const char *extra_read_only = "$bucketdir/base.1.foz";
+		auto db = std::unique_ptr<DatabaseInterface>(create_concurrent_database_with_encoded_extra_paths(
+				".__test_concurrent", DatabaseMode::Append, extra_read_only));
+		if (!db->set_bucket_path("buck", "base-other"))
+			return false;
+		if (!db->prepare())
+			return false;
+
+		const uint8_t blob[] = { 1, 2, 3 };
+		// This should be ignored since it's already in the read-only archive.
+		if (!db->write_entry(RESOURCE_SHADER_MODULE, 100, blob, sizeof(blob), 0))
+			return false;
+		if (!db->write_entry(RESOURCE_SHADER_MODULE, 101, blob, sizeof(blob), 0))
+			return false;
+	}
+
+	// Sanity check
+	{
+		auto db = std::unique_ptr<DatabaseInterface>(create_stream_archive_database(
+				".__test_concurrent.buck/base.1.foz", DatabaseMode::ReadOnly));
+		if (!db->prepare())
+			return false;
+
+		if (!db->has_entry(RESOURCE_SHADER_MODULE, 100))
+			return false;
+		if (db->has_entry(RESOURCE_SHADER_MODULE, 101))
+			return false;
+	}
+
+	{
+		auto db = std::unique_ptr<DatabaseInterface>(create_stream_archive_database(
+				".__test_concurrent.buck/base-other.1.foz", DatabaseMode::ReadOnly));
+		if (!db->prepare())
+			return false;
+
+		if (db->has_entry(RESOURCE_SHADER_MODULE, 100))
+			return false;
+		if (!db->has_entry(RESOURCE_SHADER_MODULE, 101))
+			return false;
+	}
+
+	remove(".__test_concurrent.buck/TOUCH");
+	remove(".__test_concurrent.buck/base.1.foz");
+	remove(".__test_concurrent.buck/base-other.1.foz");
 	remove(".__test_concurrent.buck");
 	return true;
 }
@@ -1241,6 +1307,8 @@ static bool test_concurrent_database_bucket()
 	if (!test_concurrent_database_bucket_write())
 		return false;
 	if (!test_concurrent_database_bucket_append())
+		return false;
+	if (!test_concurrent_database_bucket_extra_paths())
 		return false;
 
 	return true;


### PR DESCRIPTION
Add support for using a "$bucketdir/" meta-path which is resolved to the bucket's directory as appropriate.