### PR TITLE
Fix use of unauthenticated git protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "rapidjson"]
 	path = rapidjson
-	url = git://github.com/miloyip/rapidjson
+	url = https://github.com/miloyip/rapidjson
 [submodule "cli/volk"]
 	path = cli/volk
-	url = git://github.com/zeux/volk
+	url = https://github.com/zeux/volk
 [submodule "cli/SPIRV-Cross"]
 	path = cli/SPIRV-Cross
-	url = git://github.com/KhronosGroup/SPIRV-Cross
+	url = https://github.com/KhronosGroup/SPIRV-Cross
 [submodule "cli/SPIRV-Tools"]
 	path = cli/SPIRV-Tools
-	url = git://github.com/KhronosGroup/SPIRV-Tools
+	url = https://github.com/KhronosGroup/SPIRV-Tools
 [submodule "cli/SPIRV-Headers"]
 	path = cli/SPIRV-Headers
-	url = git://github.com/KhronosGroup/SPIRV-Headers
+	url = https://github.com/KhronosGroup/SPIRV-Headers
 [submodule "cli/dirent"]
 	path = cli/dirent
-	url = git://github.com/tronkko/dirent
+	url = https://github.com/tronkko/dirent


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer
supported. Today is the first brownout.

See: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Discovered via CI jobs in the FreeDesktop Gitlab instance: https://gitlab.freedesktop.org/tanty/mesa-valve-ci/-/jobs/15355568#L6136