### PR TITLE
Add workaround for missing robustness2.

### DIFF
--- a/cli/fossilize_feature_filter.cpp
+++ b/cli/fossilize_feature_filter.cpp
@@ -68,21 +68,6 @@ void *build_pnext_chain(VulkanFeatures &features, uint32_t api_version,
 	return pNext;
 }
 
-template <typename T>
-static inline const T *find_pnext(VkStructureType type, const void *pNext)
-{
-	while (pNext != nullptr)
-	{
-		auto *sin = static_cast<const VkBaseInStructure *>(pNext);
-		if (sin->sType == type)
-			return static_cast<const T*>(pNext);
-
-		pNext = sin->pNext;
-	}
-
-	return nullptr;
-}
-
 void filter_feature_enablement(VkPhysicalDeviceFeatures2 &pdf,
                                VulkanFeatures &features,
                                const VkPhysicalDeviceFeatures2 *target_features)

--- a/cli/fossilize_feature_filter.hpp
+++ b/cli/fossilize_feature_filter.hpp
@@ -154,4 +154,19 @@ private:
 	struct Impl;
 	Impl *impl;
 };
+
+template <typename T>
+static inline const T *find_pnext(VkStructureType type, const void *pNext)
+{
+	while (pNext != nullptr)
+	{
+		auto *sin = static_cast<const VkBaseInStructure *>(pNext);
+		if (sin->sType == type)
+			return static_cast<const T*>(pNext);
+
+		pNext = sin->pNext;
+	}
+
+	return nullptr;
+}
 }


### PR DESCRIPTION
DXVK and vkd3d-proton always enable robustness2. For now, until we have
new fossils captured with robustness2 PDF properly, just enable the
features.