### PR TITLE
Implement record/replay support for YcbcrConversion objects.

### DIFF
--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -24,6 +24,7 @@
 
 #include "volk.h"
 #include "fossilize_feature_filter.hpp"
+#include <vector>
 
 namespace Fossilize
 {
@@ -95,6 +96,12 @@ public:
 		return gpu_props;
 	}
 
+	// Special helper which deals with SAMPLER_YCBCR_CONVERSION_CREATE_INFO.
+	// Prefer using this instead of vkCreateSampler directly.
+	// The relevant pNext will be mutated into CONVERSION_INFO in-place if it exists.
+	// Should only be called from enqueue_create_sampler().
+	VkResult create_sampler_with_ycbcr_remap(const VkSamplerCreateInfo *create_info, VkSampler *sampler);
+
 private:
 	VkInstance instance = VK_NULL_HANDLE;
 	VkPhysicalDevice gpu = VK_NULL_HANDLE;
@@ -116,6 +123,8 @@ private:
 	VulkanFeatures features = {};
 	VulkanProperties props = {};
 	FeatureFilter feature_filter;
+
+	std::vector<VkSamplerYcbcrConversion> ycbcr_conversions;
 
 	bool format_is_supported(VkFormat format, VkFormatFeatureFlags features) override;
 };

--- a/cli/fossilize_disasm.cpp
+++ b/cli/fossilize_disasm.cpp
@@ -178,7 +178,7 @@ struct FilterReplayer : StateCreatorInterface
 
 struct DisasmReplayer : StateCreatorInterface
 {
-	DisasmReplayer(const VulkanDevice *device_)
+	DisasmReplayer(VulkanDevice *device_)
 		: device(device_)
 	{
 		if (device)
@@ -226,7 +226,7 @@ struct DisasmReplayer : StateCreatorInterface
 		if (device)
 		{
 			LOGI("Creating sampler %0" PRIX64 "\n", hash);
-			if (vkCreateSampler(device->get_device(), create_info, nullptr, sampler) != VK_SUCCESS)
+			if (device->create_sampler_with_ycbcr_remap(create_info, sampler) != VK_SUCCESS)
 			{
 				LOGE(" ... Failed!\n");
 				return false;
@@ -473,7 +473,7 @@ struct DisasmReplayer : StateCreatorInterface
 		       !filter_raytracing.empty() || !filter_modules.empty();
 	}
 
-	const VulkanDevice *device;
+	VulkanDevice *device;
 
 	vector<const VkSamplerCreateInfo *> sampler_infos;
 	vector<const VkDescriptorSetLayoutCreateInfo *> set_layout_infos;

--- a/cli/fossilize_feature_filter.cpp
+++ b/cli/fossilize_feature_filter.cpp
@@ -794,6 +794,21 @@ bool FeatureFilter::Impl::pnext_chain_is_supported(const void *pNext) const
 			break;
 		}
 
+		case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
+		case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO:
+		{
+			// Should also validate formats and all sorts of feature bits, but
+			// consider that TODO for now.
+			// YcbcrConversionCreateInfo is inlined into a VkSamplerCreateInfo when replaying from a Fossilize archive.
+			// Normally, it's not a pNext, but we pretend it is to make capture and replay
+			// a bit more sane.
+			if (!enabled_extensions.count(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) ||
+			    !features.ycbcr_conversion.samplerYcbcrConversion)
+				return false;
+
+			break;
+		}
+
 		default:
 			LOGE("Unrecognized pNext sType: %u. Treating as unsupported.\n", unsigned(base->sType));
 			return false;

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -1731,12 +1731,12 @@ struct ThreadedReplayer : StateCreatorInterface
 			return false;
 		}
 
-		// Playback in-order.
-		if (vkCreateSampler(device->get_device(), create_info, nullptr, sampler) != VK_SUCCESS)
+		if (device->create_sampler_with_ycbcr_remap(create_info, sampler) != VK_SUCCESS)
 		{
 			LOGE("Creating sampler %016" PRIx64 " Failed!\n", index);
 			return false;
 		}
+
 		samplers[index] = *sampler;
 		return true;
 	}

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -116,6 +116,10 @@ public:
 	                                          ResourceTag /*blob_tag*/,
 	                                          Hash /*blob_hash*/) {}
 
+	// SAMPLER_YCBCR_CONVERSION_CREATE_INFO is added as a pNext here, instead of YCBCR_CONVERSION_INFO.
+	// Replaying application needs to detect that pNext, create its own YCbCr object and replace the struct
+	// with a YCBCR_CONVERSION_INFO.
+	// See Device::create_sampler_with_ycbcr_remap().
 	virtual bool enqueue_create_sampler(Hash hash, const VkSamplerCreateInfo *create_info, VkSampler *sampler) = 0;
 	virtual bool enqueue_create_descriptor_set_layout(Hash hash, const VkDescriptorSetLayoutCreateInfo *create_info, VkDescriptorSetLayout *layout) = 0;
 	virtual bool enqueue_create_pipeline_layout(Hash hash, const VkPipelineLayoutCreateInfo *create_info, VkPipelineLayout *layout) = 0;

--- a/fossilize.hpp
+++ b/fossilize.hpp
@@ -225,6 +225,12 @@ public:
 	bool record_raytracing_pipeline(VkPipeline pipeline, const VkRayTracingPipelineCreateInfoKHR &create_info,
 	                                const VkPipeline *base_pipelines, uint32_t base_pipeline_count,
 	                                Hash custom_hash = 0) FOSSILIZE_WARN_UNUSED;
+	// YCbCr conversion objects are treated somewhat differently and their create infos
+	// are inlined into a sampler create info.
+	// In a replay scenario, the YCbCr create info is fished out of the pNext chain and replaced
+	// with a Conversion Info.
+	bool record_ycbcr_conversion(VkSamplerYcbcrConversion conv,
+	                             const VkSamplerYcbcrConversionCreateInfo &create_info) FOSSILIZE_WARN_UNUSED;
 
 	// Used by hashing functions in Hashing namespace. Should be considered an implementation detail.
 	bool get_hash_for_descriptor_set_layout(VkDescriptorSetLayout layout, Hash *hash) const FOSSILIZE_WARN_UNUSED;

--- a/layer/dispatch.cpp
+++ b/layer/dispatch.cpp
@@ -608,6 +608,42 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(VkDevice device, cons
 	return res;
 }
 
+static VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
+		VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+		const VkAllocationCallbacks *pCallbacks,
+		VkSamplerYcbcrConversion *pConversion)
+{
+	auto *layer = get_device_layer(device);
+
+	auto res = layer->getTable()->CreateSamplerYcbcrConversion(device, pCreateInfo, pCallbacks, pConversion);
+
+	if (res == VK_SUCCESS)
+	{
+		if (!layer->getRecorder().record_ycbcr_conversion(*pConversion, *pCreateInfo))
+			LOGW_LEVEL("Failed to record YCbCr conversion, usually caused by unsupported pNext.\n");
+	}
+
+	return res;
+}
+
+static VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
+		VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+		const VkAllocationCallbacks *pCallbacks,
+		VkSamplerYcbcrConversion *pConversion)
+{
+	auto *layer = get_device_layer(device);
+
+	auto res = layer->getTable()->CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pCallbacks, pConversion);
+
+	if (res == VK_SUCCESS)
+	{
+		if (!layer->getRecorder().record_ycbcr_conversion(*pConversion, *pCreateInfo))
+			LOGW_LEVEL("Failed to record YCbCr conversion, usually caused by unsupported pNext.\n");
+	}
+
+	return res;
+}
+
 static PFN_vkVoidFunction interceptCoreDeviceCommand(const char *pName)
 {
 	static const struct
@@ -627,6 +663,8 @@ static PFN_vkVoidFunction interceptCoreDeviceCommand(const char *pName)
 		{ "vkCreateRenderPass", reinterpret_cast<PFN_vkVoidFunction>(CreateRenderPass) },
 		{ "vkCreateRenderPass2", reinterpret_cast<PFN_vkVoidFunction>(CreateRenderPass2) },
 		{ "vkCreateRenderPass2KHR", reinterpret_cast<PFN_vkVoidFunction>(CreateRenderPass2KHR) },
+		{ "vkCreateSamplerYcbcrConversion", reinterpret_cast<PFN_vkVoidFunction>(CreateSamplerYcbcrConversion) },
+		{ "vkCreateSamplerYcbcrConversionKHR", reinterpret_cast<PFN_vkVoidFunction>(CreateSamplerYcbcrConversionKHR) },
 		{ "vkCreateRayTracingPipelinesKHR", reinterpret_cast<PFN_vkVoidFunction>(CreateRayTracingPipelinesKHR) },
 	};
 

--- a/layer/dispatch_helper.cpp
+++ b/layer/dispatch_helper.cpp
@@ -39,6 +39,8 @@ void layerInitDeviceDispatchTable(VkDevice device, VkLayerDispatchTable *table, 
 	table->CreateRenderPass = (PFN_vkCreateRenderPass)gpa(device, "vkCreateRenderPass");
 	table->CreateRenderPass2 = (PFN_vkCreateRenderPass2)gpa(device, "vkCreateRenderPass2");
 	table->CreateRenderPass2KHR = (PFN_vkCreateRenderPass2KHR)gpa(device, "vkCreateRenderPass2KHR");
+	table->CreateSamplerYcbcrConversion = (PFN_vkCreateSamplerYcbcrConversion)gpa(device, "vkCreateSamplerYcbcrConversion");
+	table->CreateSamplerYcbcrConversionKHR = (PFN_vkCreateSamplerYcbcrConversionKHR)gpa(device, "vkCreateSamplerYcbcrConversionKHR");
 	table->CreateRayTracingPipelinesKHR = (PFN_vkCreateRayTracingPipelinesKHR)gpa(device, "vkCreateRayTracingPipelinesKHR");
 }
 

--- a/layer/dispatch_helper.hpp
+++ b/layer/dispatch_helper.hpp
@@ -59,6 +59,8 @@ struct VkLayerDispatchTable
 	PFN_vkCreateRenderPass CreateRenderPass;
 	PFN_vkCreateRenderPass2 CreateRenderPass2;
 	PFN_vkCreateRenderPass2KHR CreateRenderPass2KHR;
+	PFN_vkCreateSamplerYcbcrConversion CreateSamplerYcbcrConversion;
+	PFN_vkCreateSamplerYcbcrConversionKHR CreateSamplerYcbcrConversionKHR;
 	PFN_vkCreateRayTracingPipelinesKHR CreateRayTracingPipelinesKHR;
 };
 


### PR DESCRIPTION
Inline the inline create info rather than introducing a ton of new objects which will require a lot of new entry points, object types, and just a ton of churn in general. The conversion object is kinda meaningless on its own, so just create it on-demand in the replayer device.