### PR TITLE
Add request_shutdown() which will terminate prepare().  This can be u…

### DIFF
--- a/fossilize_db.hpp
+++ b/fossilize_db.hpp
@@ -195,6 +195,11 @@ public:
 	// See further comments after create_concurrent_database().
 	virtual bool set_bucket_path(const char *bucket_dirname, const char *bucket_basename);
 
+	// Request termination of prepare() which can take a long time for very
+	// large archives.  This is useful if running prepare() on a thread and the need
+	// arises to stop loading the database.
+	static void request_shutdown();
+
 protected:
 	bool test_resource_filter(ResourceTag tag, Hash hash) const;
 	bool add_to_implicit_whitelist(DatabaseInterface &iface);


### PR DESCRIPTION
…sed if prepare() is running on a thread and the thread needs to shutdown while it is running (for example, on very large archives).