### PR TITLE
Add --disable-signal-handler for debugging and coredump-ing.

### DIFF
--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -129,6 +129,9 @@ public:
 		// Enable full validation layers.
 		bool enable_validation;
 
+		// Disable crash signal handler (for debugging and obtaining coredumps).
+		bool disable_signal_handler;
+
 		// Ignores derived pipelines, reduces memory consumption when replaying.
 		// Only useful if the driver in question ignores use of derived pipelines when hashing pipelines internally.
 		// OBSOLETE. This option is only kept for backwards compat.

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -684,6 +684,9 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	if (options.enable_validation)
 		argv.push_back("--enable-validation");
 
+	if (options.disable_signal_handler)
+		argv.push_back("--disable-signal-handler");
+
 	if (options.null_device)
 		argv.push_back("--null-device");
 


### PR DESCRIPTION
In case of a hard to reproduce driver / compiler crash, it's desirable to have a way that does not require attaching a debugger to Fossilize to get a crash dump / stack trace.

By using this option to disable the signal handler, the crashes will be directly passed on to a coredump handler (e.g. systemd-coredump), which the developer can use to diagnose the crash after-the-fact.

Tested with robust and non-robust mode, on SEGV, ABRT and timeout-triggered ABRT.