### PR TITLE
Add maintenance7 support for dynamic descriptors

### DIFF
--- a/cli/fossilize_feature_filter.cpp
+++ b/cli/fossilize_feature_filter.cpp
@@ -1896,10 +1896,22 @@ bool FeatureFilter::Impl::descriptor_set_layout_is_supported(const VkDescriptorS
 
 	if (pool_is_update_after_bind)
 	{
-		if (counts.ubo_dynamic > props.descriptor_indexing.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic)
-			return false;
-		if (counts.ssbo_dynamic > props.descriptor_indexing.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic)
-			return false;
+		if (features.maintenance7.maintenance7)
+		{
+			if (counts.ubo_dynamic > props.maintenance7.maxDescriptorSetUpdateAfterBindTotalUniformBuffersDynamic)
+				return false;
+			if (counts.ssbo_dynamic > props.maintenance7.maxDescriptorSetUpdateAfterBindTotalStorageBuffersDynamic)
+				return false;
+			if ((counts.ubo_dynamic + counts.ssbo_dynamic) > props.maintenance7.maxDescriptorSetUpdateAfterBindTotalBuffersDynamic)
+				return false;
+		}
+		else
+		{
+			if (counts.ubo_dynamic > props.descriptor_indexing.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic)
+				return false;
+			if (counts.ssbo_dynamic > props.descriptor_indexing.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic)
+				return false;
+		}
 		if (counts.ubo > props.descriptor_indexing.maxDescriptorSetUpdateAfterBindUniformBuffers)
 			return false;
 		if (counts.ssbo > props.descriptor_indexing.maxDescriptorSetUpdateAfterBindStorageBuffers)
@@ -1917,10 +1929,22 @@ bool FeatureFilter::Impl::descriptor_set_layout_is_supported(const VkDescriptorS
 	}
 	else
 	{
-		if (counts.ubo_dynamic > props2.properties.limits.maxDescriptorSetUniformBuffersDynamic)
-			return false;
-		if (counts.ssbo_dynamic > props2.properties.limits.maxDescriptorSetStorageBuffersDynamic)
-			return false;
+		if (features.maintenance7.maintenance7)
+		{
+			if (counts.ubo_dynamic > props.maintenance7.maxDescriptorSetTotalUniformBuffersDynamic)
+				return false;
+			if (counts.ssbo_dynamic > props.maintenance7.maxDescriptorSetTotalStorageBuffersDynamic)
+				return false;
+			if ((counts.ubo_dynamic + counts.ssbo_dynamic) > props.maintenance7.maxDescriptorSetTotalBuffersDynamic)
+				return false;
+		}
+		else
+		{
+			if (counts.ubo_dynamic > props2.properties.limits.maxDescriptorSetUniformBuffersDynamic)
+				return false;
+			if (counts.ssbo_dynamic > props2.properties.limits.maxDescriptorSetStorageBuffersDynamic)
+				return false;
+		}
 		if (counts.ubo > props2.properties.limits.maxDescriptorSetUniformBuffers)
 			return false;
 		if (counts.ssbo > props2.properties.limits.maxDescriptorSetStorageBuffers)

--- a/cli/fossilize_feature_filter.hpp
+++ b/cli/fossilize_feature_filter.hpp
@@ -55,6 +55,7 @@ struct VulkanFeatures
 	VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering;
 	VkPhysicalDeviceMaintenance4FeaturesKHR maintenance4;
 	VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5;
+	VkPhysicalDeviceMaintenance7FeaturesKHR maintenance7;
 	VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR zero_initialize_workgroup_memory;
 	VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback;
 	VkPhysicalDeviceDepthClipEnableFeaturesEXT depth_clip;
@@ -175,6 +176,7 @@ struct VulkanProperties
 	VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader;
 	VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT shader_module_identifier;
 	VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced;
+	VkPhysicalDeviceMaintenance7PropertiesKHR maintenance7;
 
 	struct
 	{

--- a/cli/fossilize_feature_filter_features.inc
+++ b/cli/fossilize_feature_filter_features.inc
@@ -85,6 +85,7 @@ FE(NON_SEAMLESS_CUBE_MAP, non_seamless_cube_map, EXT);
 FE(ATTACHMENT_FEEDBACK_LOOP_LAYOUT, attachment_feedback_loop_layout, EXT);
 FE(MAINTENANCE_4, maintenance4, KHR);
 FE(MAINTENANCE_5, maintenance5, KHR);
+FE(MAINTENANCE_7, maintenance7, KHR);
 FE(SHADER_MODULE_IDENTIFIER, shader_module_identifier, EXT);
 FE(RAY_TRACING_MAINTENANCE_1, ray_tracing_maintenance1, KHR);
 FE(RAY_TRACING_MOTION_BLUR, ray_tracing_motion_blur_nv, NV);

--- a/cli/fossilize_feature_filter_properties.inc
+++ b/cli/fossilize_feature_filter_properties.inc
@@ -37,3 +37,4 @@ PE(EXTENDED_DYNAMIC_STATE_3, extended_dynamic_state3, EXT);
 PE(MESH_SHADER, mesh_shader, EXT);
 PE(SHADER_MODULE_IDENTIFIER, shader_module_identifier, EXT);
 PE(BLEND_OPERATION_ADVANCED, blend_operation_advanced, EXT);
+PE(MAINTENANCE_7, maintenance7, KHR);


### PR DESCRIPTION
The limits got more precise in maintenance7 and that is helping replay some traces that would otherwise not replay on Anv. 

Our limit is 16 dynamic descriptor in total, but we had to expose 8 for ubo/ssbo in the legacy limit.