### PR TITLE
convert sprintf calls to snprintf

### DIFF
--- a/cli/fossilize_disasm.cpp
+++ b/cli/fossilize_disasm.cpp
@@ -876,7 +876,7 @@ static void print_help()
 static string uint64_string(uint64_t value)
 {
 	char str[17]; // 16 digits + null
-	sprintf(str, "%016" PRIx64, value);
+	snprintf(str, sizeof(str), "%016" PRIx64, value);
 	return string(str);
 }
 

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -1692,7 +1692,7 @@ struct ThreadedReplayer : StateCreatorInterface
 				auto &props = device->get_module_identifier_properties();
 				char uuid_string[2 * VK_UUID_SIZE + 1];
 				for (unsigned i = 0; i < VK_UUID_SIZE; i++)
-					sprintf(uuid_string + 2 * i, "%02x", props.shaderModuleIdentifierAlgorithmUUID[i]);
+					snprintf(uuid_string + 2 * i, 2 * VK_UUID_SIZE + 1 - 2 * i, "%02x", props.shaderModuleIdentifierAlgorithmUUID[i]);
 
 				report_module_uuid(uuid_string);
 

--- a/fossilize.cpp
+++ b/fossilize.cpp
@@ -111,7 +111,7 @@ template <typename Allocator>
 static Value uint64_string(uint64_t value, Allocator &alloc)
 {
 	char str[17]; // 16 digits + null
-	sprintf(str, "%016" PRIx64, value);
+	snprintf(str, sizeof(str), "%016" PRIx64, value);
 	return Value(str, alloc);
 }
 

--- a/fossilize_db.cpp
+++ b/fossilize_db.cpp
@@ -594,7 +594,7 @@ struct DumbDirectoryDatabase : DatabaseInterface
 			return false;
 
 		char filename[25]; // 2 digits + "." + 16 digits + ".json" + null
-		sprintf(filename, "%02x.%016" PRIx64 ".json", static_cast<unsigned>(tag), hash);
+		snprintf(filename, sizeof(filename), "%02x.%016" PRIx64 ".json", static_cast<unsigned>(tag), hash);
 		auto path = Path::join(base_directory, filename);
 
 		FILE *file = fopen(path.c_str(), "rb");
@@ -646,7 +646,7 @@ struct DumbDirectoryDatabase : DatabaseInterface
 			return true;
 
 		char filename[25]; // 2 digits + "." + 16 digits + ".json" + null
-		sprintf(filename, "%02x.%016" PRIx64 ".json", static_cast<unsigned>(tag), hash);
+		snprintf(filename, sizeof(filename), "%02x.%016" PRIx64 ".json", static_cast<unsigned>(tag), hash);
 		auto path = Path::join(base_directory, filename);
 
 		FILE *file = fopen(path.c_str(), "wb");
@@ -862,8 +862,8 @@ struct ZipDatabase : DatabaseInterface
 			return true;
 
 		char str[FOSSILIZE_BLOB_HASH_LENGTH + 1]; // 40 digits + null
-		sprintf(str, "%0*x", FOSSILIZE_BLOB_HASH_LENGTH - 16, tag);
-		sprintf(str + FOSSILIZE_BLOB_HASH_LENGTH - 16, "%016" PRIx64, hash);
+		snprintf(str, FOSSILIZE_BLOB_HASH_LENGTH + 1, "%0*x", FOSSILIZE_BLOB_HASH_LENGTH - 16, tag);
+		snprintf(str + FOSSILIZE_BLOB_HASH_LENGTH - 16, 17, "%016" PRIx64, hash);
 
 		unsigned mz_flags;
 		if ((flags & PAYLOAD_WRITE_COMPRESS_BIT) != 0)
@@ -1353,8 +1353,8 @@ struct StreamArchive : DatabaseInterface
 			return true;
 
 		char str[FOSSILIZE_BLOB_HASH_LENGTH + 1]; // 40 digits + null
-		sprintf(str, "%0*x", FOSSILIZE_BLOB_HASH_LENGTH - 16, tag);
-		sprintf(str + FOSSILIZE_BLOB_HASH_LENGTH - 16, "%016" PRIx64, hash);
+		snprintf(str, FOSSILIZE_BLOB_HASH_LENGTH + 1, "%0*x", FOSSILIZE_BLOB_HASH_LENGTH - 16, tag);
+		snprintf(str + FOSSILIZE_BLOB_HASH_LENGTH - 16, 17, "%016" PRIx64, hash);
 
 		if (fwrite(str, 1, FOSSILIZE_BLOB_HASH_LENGTH, file) != FOSSILIZE_BLOB_HASH_LENGTH)
 			return false;

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -593,7 +593,7 @@ bool ExternalReplayer::Impl::get_raytracing_failed_validation(size_t *count, Has
 void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Options &options, int ctl_fd)
 {
 	char fd_name[16], control_fd_name[16];
-	sprintf(fd_name, "%d", fd);
+	snprintf(fd_name, sizeof(fd_name), "%d", fd);
 	char num_thread_holder[16];
 
 	std::string self_path;
@@ -627,7 +627,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	if (ctl_fd >= 0)
 	{
 		argv.push_back("--control-fd");
-		sprintf(control_fd_name, "%d", ctl_fd);
+		snprintf(control_fd_name, sizeof(control_fd_name), "%d", ctl_fd);
 		argv.push_back(control_fd_name);
 	}
 
@@ -637,7 +637,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	if (options.num_threads)
 	{
 		argv.push_back("--num-threads");
-		sprintf(num_thread_holder, "%u", options.num_threads);
+		snprintf(num_thread_holder, sizeof(num_thread_holder), "%u", options.num_threads);
 		argv.push_back(num_thread_holder);
 	}
 
@@ -671,7 +671,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 		argv.push_back("--on-disk-replay-whitelist");
 		argv.push_back(options.on_disk_replay_whitelist);
 
-		sprintf(whitelist_hex, "%x", options.on_disk_replay_whitelist_mask);
+		snprintf(whitelist_hex, sizeof(whitelist_hex), "%x", options.on_disk_replay_whitelist_mask);
 		argv.push_back("--on-disk-replay-whitelist-mask");
 		argv.push_back(whitelist_hex);
 	}
@@ -701,7 +701,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 
 	argv.push_back("--device-index");
 	char index_name[16];
-	sprintf(index_name, "%u", options.device_index);
+	snprintf(index_name, sizeof(index_name), "%u", options.device_index);
 	argv.push_back(index_name);
 
 	char graphics_range_start[16], graphics_range_end[16];
@@ -711,20 +711,20 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	if (options.use_pipeline_range)
 	{
 		argv.push_back("--graphics-pipeline-range");
-		sprintf(graphics_range_start, "%u", options.start_graphics_index);
-		sprintf(graphics_range_end, "%u", options.end_graphics_index);
+		snprintf(graphics_range_start, sizeof(graphics_range_start), "%u", options.start_graphics_index);
+		snprintf(graphics_range_end, sizeof(graphics_range_end), "%u", options.end_graphics_index);
 		argv.push_back(graphics_range_start);
 		argv.push_back(graphics_range_end);
 
 		argv.push_back("--compute-pipeline-range");
-		sprintf(compute_range_start, "%u", options.start_compute_index);
-		sprintf(compute_range_end, "%u", options.end_compute_index);
+		snprintf(compute_range_start, sizeof(compute_range_start), "%u", options.start_compute_index);
+		snprintf(compute_range_end, sizeof(compute_range_end), "%u", options.end_compute_index);
 		argv.push_back(compute_range_start);
 		argv.push_back(compute_range_end);
 
 		argv.push_back("--raytracing-pipeline-range");
-		sprintf(raytracing_range_start, "%u", options.start_raytracing_index);
-		sprintf(raytracing_range_end, "%u", options.end_raytracing_index);
+		snprintf(raytracing_range_start, sizeof(raytracing_range_start), "%u", options.start_raytracing_index);
+		snprintf(raytracing_range_end, sizeof(raytracing_range_end), "%u", options.end_raytracing_index);
 		argv.push_back(raytracing_range_start);
 		argv.push_back(raytracing_range_end);
 	}
@@ -739,7 +739,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	if (options.timeout_seconds)
 	{
 		argv.push_back("--timeout-seconds");
-		sprintf(timeout, "%u", options.timeout_seconds);
+		snprintf(timeout, sizeof(timeout), "%u", options.timeout_seconds);
 		argv.push_back(timeout);
 	}
 
@@ -748,7 +748,7 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	for (unsigned i = 0; i < options.num_implicit_whitelist_indices; i++)
 	{
 		argv.push_back("--implicit-whitelist");
-		sprintf(implicit_indices[i].data(), "%u", options.implicit_whitelist_indices[i]);
+		snprintf(implicit_indices[i].data(), implicit_indices[i].size(), "%u", options.implicit_whitelist_indices[i]);
 		argv.push_back(implicit_indices[i].data());
 	}
 
@@ -884,7 +884,7 @@ static bool create_low_priority_autogroup()
 bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 {
 	char shm_name[256];
-	sprintf(shm_name, "/fossilize-external-%d-%d", getpid(), shm_index.fetch_add(1, std::memory_order_relaxed));
+	snprintf(shm_name, sizeof(shm_name), "/fossilize-external-%d-%d", getpid(), shm_index.fetch_add(1, std::memory_order_relaxed));
 	fd = shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, 0600);
 	if (fd < 0)
 	{

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -442,8 +442,8 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 
 	char shm_name[256];
 	char shm_mutex_name[256];
-	sprintf(shm_name, "fossilize-external-%lu-%d", GetCurrentProcessId(), shm_index.fetch_add(1, std::memory_order_relaxed));
-	sprintf(shm_mutex_name, "fossilize-external-%lu-%d", GetCurrentProcessId(), shm_index.fetch_add(1, std::memory_order_relaxed));
+	snprintf(shm_name, sizeof(shm_name), "fossilize-external-%lu-%d", GetCurrentProcessId(), shm_index.fetch_add(1, std::memory_order_relaxed));
+	snprintf(shm_mutex_name, sizeof(shm_mutex_name), "fossilize-external-%lu-%d", GetCurrentProcessId(), shm_index.fetch_add(1, std::memory_order_relaxed));
 	mapping_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, (DWORD)shm_block_size, shm_name);
 
 	if (!mapping_handle)
@@ -563,7 +563,7 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 
 		cmdline += " --on-disk-replay-whitelist-mask ";
 		char whitelist_hex[9];
-		sprintf(whitelist_hex, "%x", options.on_disk_replay_whitelist_mask);
+		snprintf(whitelist_hex, sizeof(whitelist_hex), "%x", options.on_disk_replay_whitelist_mask);
 		cmdline += whitelist_hex;
 	}
 

--- a/layer/instance.cpp
+++ b/layer/instance.cpp
@@ -382,7 +382,7 @@ StateRecorder *Instance::getStateRecorderForDevice(const VkPhysicalDevicePropert
 		needsBucket = false;
 
 	char hashString[17];
-	sprintf(hashString, "%016" PRIx64, hash);
+	snprintf(hashString, sizeof(hashString), "%016" PRIx64, hash);
 
 	// Try to normalize the path layouts for last use.
 	// Without buckets:
@@ -420,7 +420,7 @@ StateRecorder *Instance::getStateRecorderForDevice(const VkPhysicalDevicePropert
 	{
 		char bucketPath[17];
 		Hash bucketHash = infoFilter->get_bucket_hash(props, appInfo, device_pnext);
-		sprintf(bucketPath, "%016" PRIx64, bucketHash);
+		snprintf(bucketPath, sizeof(bucketPath), "%016" PRIx64, bucketHash);
 
 		// For convenience. Makes filenames similar in top-level directory and bucket directories.
 		auto basename = Path::basename(serializationPath);
@@ -465,7 +465,7 @@ StateRecorder *Instance::getStateRecorderForDevice(const VkPhysicalDevicePropert
 		{
 			char uuidString[2 * VK_UUID_SIZE + 1];
 			for (unsigned i = 0; i < VK_UUID_SIZE; i++)
-				sprintf(uuidString + 2 * i, "%02x", identifierProps->shaderModuleIdentifierAlgorithmUUID[i]);
+				snprintf(uuidString + 2 * i, 2 * VK_UUID_SIZE + 1 - 2 * i, "%02x", identifierProps->shaderModuleIdentifierAlgorithmUUID[i]);
 
 			std::string identifierDatabasePath = identifierPath;
 			identifierDatabasePath += '.';

--- a/miniz/examples/example2.c
+++ b/miniz/examples/example2.c
@@ -55,8 +55,8 @@ int main(int argc, char *argv[])
   // Append a bunch of text files to the test archive
   for (i = (N - 1); i >= 0; --i)
   {
-    sprintf(archive_filename, "%u.txt", i);
-    sprintf(data, "%u %s %u", (N - 1) - i, s_pTest_str, i);
+    snprintf(archive_filename, sizeof(archive_filename), "%u.txt", i);
+    snprintf(data, sizeof(data), "%u %s %u", (N - 1) - i, s_pTest_str, i);
 
     // Add a new file to the archive. Note this is an IN-PLACE operation, so if it fails your archive is probably hosed (its central directory may not be complete) but it should be recoverable using zip -F or -FF. So use caution with this guy.
     // A more robust way to add a file to an archive would be to read it into memory, perform the operation, then write a new archive out to a temp file and then delete/rename the files.
@@ -127,8 +127,8 @@ int main(int argc, char *argv[])
 
     for (i = 0; i < N; i++)
     {
-      sprintf(archive_filename, "%u.txt", i);
-      sprintf(data, "%u %s %u", (N - 1) - i, s_pTest_str, i);
+      snprintf(archive_filename, sizeof(archive_filename), "%u.txt", i);
+      snprintf(data, sizeof(data), "%u %s %u", (N - 1) - i, s_pTest_str, i);
 
       // Try to extract all the files to the heap.
       p = mz_zip_reader_extract_file_to_heap(&zip_archive, archive_filename, &uncomp_size, 0);


### PR DESCRIPTION
Partly addresses:

    mac build provokes warnings
    https://github.com/ValveSoftware/Fossilize/issues/266

Many implementations have deprecated sprintf() in favor of snprintf(), including macOS with latest Xcode and Windows if _CRT_SECURE_NO_WARNINGS is set.

This change converts all uses of sprintf() to snprintf().  In most cases this is simply converting
    sprintf(x, ...)
to
    snprintf(x, sizeof(x), ...)

But there are a few more complicated constructions in fossilize_replay.cpp, fossilize_db.cpp, and layer/instance.cpp.