### PR TITLE
Create PSO-dependency objects lazily.

### DIFF
--- a/cli/device.cpp
+++ b/cli/device.cpp
@@ -745,7 +745,7 @@ get_physical_device_properties(VkPhysicalDevice, VkPhysicalDeviceProperties *pro
 	props->apiVersion = VK_API_VERSION_1_1;
 }
 
-VkResult VulkanDevice::create_sampler_with_ycbcr_remap(const VkSamplerCreateInfo *create_info, VkSampler *sampler)
+VkResult VulkanDevice::resolve_sampler_with_ycbcr_remap(VkSamplerCreateInfo *create_info)
 {
 	VkSamplerYcbcrConversion conv = VK_NULL_HANDLE;
 	VkResult vr;
@@ -775,9 +775,16 @@ VkResult VulkanDevice::create_sampler_with_ycbcr_remap(const VkSamplerCreateInfo
 		next = static_cast<const VkBaseInStructure *>(next->pNext);
 	}
 
+	return VK_SUCCESS;
+}
+
+VkResult VulkanDevice::create_sampler_with_ycbcr_remap(const VkSamplerCreateInfo *create_info, VkSampler *sampler)
+{
+	auto vr = resolve_sampler_with_ycbcr_remap(const_cast<VkSamplerCreateInfo *>(create_info));
+	if (vr != VK_SUCCESS)
+		return vr;
 	if ((vr = vkCreateSampler(device, create_info, nullptr, sampler)) != VK_SUCCESS)
 		return vr;
-
 	return VK_SUCCESS;
 }
 

--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -111,6 +111,7 @@ public:
 	// The relevant pNext will be mutated into CONVERSION_INFO in-place if it exists.
 	// Should only be called from enqueue_create_sampler().
 	VkResult create_sampler_with_ycbcr_remap(const VkSamplerCreateInfo *create_info, VkSampler *sampler);
+	VkResult resolve_sampler_with_ycbcr_remap(VkSamplerCreateInfo *create_info);
 
 private:
 	VkInstance instance = VK_NULL_HANDLE;

--- a/cli/fossilize_feature_filter.cpp
+++ b/cli/fossilize_feature_filter.cpp
@@ -4573,6 +4573,12 @@ bool FeatureFilter::supports_scalar_block_layout() const
 	return impl->null_device || impl->features.vk12.scalarBlockLayout;
 }
 
+bool FeatureFilter::supports_maintenance4() const
+{
+	return impl->null_device || impl->features.maintenance4.maintenance4 ||
+	       impl->api_version >= VK_MAKE_VERSION(1, 3, 0);
+}
+
 void FeatureFilter::set_device_query_interface(DeviceQueryInterface *iface)
 {
 	impl->query = iface;

--- a/cli/fossilize_feature_filter.hpp
+++ b/cli/fossilize_feature_filter.hpp
@@ -235,6 +235,7 @@ public:
 	void unregister_shader_module_info(VkShaderModule module);
 
 	bool supports_scalar_block_layout() const;
+	bool supports_maintenance4() const;
 
 private:
 	struct Impl;


### PR DESCRIPTION
NV has some horrible memory bloat while replaying pipeline layouts, which can lead to > 1 GB memory usage just replaying layouts before anything else in some cases, which leads to OOM in multi-process runs. Fix this so that objects are created lazily and destroyed right after instead, which works around the issue.

Closes #269.