### PR TITLE
Thread pin + fossilize_replay refactor

### DIFF
--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -260,11 +260,13 @@ static void report_module_uuid(const char (&path)[2 * VK_UUID_SIZE + 1]);
 static void timeout_handler();
 static void begin_heartbeat();
 static void heartbeat();
+static void set_affinity(int cpu_index);
 #else
 #define report_module_uuid(x) ((void)(x))
 #define timeout_handler() ((void)0)
 #define begin_heartbeat() ((void)0)
 #define heartbeat() ((void)0)
+#define set_affinity(cpu_index) ((void)(cpu_index))
 #endif
 
 struct PipelineWorkItem
@@ -1744,8 +1746,11 @@ struct ThreadedReplayer : StateCreatorInterface
 		resolver.flush(device.get());
 	}
 
+    // thread_index starts at 1
 	void worker_thread(unsigned thread_index)
 	{
+        set_affinity(thread_index - 1);
+
 		Global::worker_thread_index = thread_index;
 
 		if (opts.on_thread_callback)

--- a/cli/fossilize_replay_windows.hpp
+++ b/cli/fossilize_replay_windows.hpp
@@ -30,6 +30,11 @@
 #include "fossilize_external_replayer.hpp"
 #include <inttypes.h>
 
+static void set_affinity(int)
+{
+    //TODO WIN32 API
+}
+
 static bool write_all(HANDLE file, const char *str)
 {
 	size_t len = strlen(str);


### PR DESCRIPTION
I have 32 threads on my CPU.
I have an issue where the scheduler is apparently putting all the work on threads 0 to 6 and 16 to 22.
Now with my fix the CPU usage is going from 27 to 64%.

I have not implemented the thread pin for Windows.
I have some checks to do on the C++ fossilize_replay refactor.

<img width="2006" height="1580" alt="schedule_fix" src="https://github.com/user-attachments/assets/70f241fd-22ca-477e-b525-65d51ab03332" />
<img width="2010" height="1697" alt="schedule_bug" src="https://github.com/user-attachments/assets/ef548434-47d3-4470-9f8b-e98917e83b3b" />

