### PR TITLE
Add log connectivity parameter to fossilize-list

### DIFF
--- a/cli/fossilize_list.cpp
+++ b/cli/fossilize_list.cpp
@@ -274,12 +274,9 @@ void print_connectivity(Hash hash, const ListReplayer &list_replayer)
 {
 	auto saved_hashes_map = list_replayer.saved_hashes_map.find(hash);
 	if (saved_hashes_map != list_replayer.saved_hashes_map.end())
-	{
 		for (auto par : saved_hashes_map->second)
-		{
 			printf("%s(%d):%016" PRIx64 ", ", tag_names[par.first], par.first, par.second);
-		}
-	}
+	printf("\n");
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR adds the `--connectivity` parameter to `fossilize-list`. Connectivity in this case refers to the hashes of objects referenced by the hash of the selected tag (via the `--tag` parameter), or in other words, the hashes of objects associated with that hash.

Example for Graphics Pipeline:
<img width="1904" height="106" alt="image" src="https://github.com/user-attachments/assets/8f906984-46e1-4b27-ab13-57e9b2c8a43b" />