### PR TITLE
fossilize: Suppress unused-result warning from gcc

### DIFF
--- a/cli/fossilize_replay_linux.hpp
+++ b/cli/fossilize_replay_linux.hpp
@@ -1286,7 +1286,8 @@ static int run_master_process(const VulkanDevice::Options &opts,
 						if (proc.watchdog_timer_fd >= 0)
 						{
 							uint64_t dummy;
-							(void)::read(proc.watchdog_timer_fd, &dummy, sizeof(dummy));
+							ssize_t ret_dummy = ::read(proc.watchdog_timer_fd, &dummy, sizeof(dummy));
+							(void)ret_dummy;
 
 							// Hitting watchdog timer while asleep is okay.
 							if (!proc.stopped)


### PR DESCRIPTION
- We recently enabled -Werror in some Linux builds which turned this warning into an error. Apparently GCC has decided (or waffled on) allowing cast-to-void to suppress unused-result (while Clang supports it) so this warns it all version of GCC. We'd like to leave -Wunused-result enabled in all builds so stubbing the return here to suppress the warning.

In file included from /data/src/external/fossilize/cli/fossilize_replay.cpp:4524: /data/src/external/fossilize/cli/fossilize_replay_linux.hpp: In function 'int run_master_process(const Fossilize::VulkanDevice::Options&, const ThreadedReplayer::Options&, const std::vector<const char*>&, const char*, uint32_t, bool, int, int)': /data/src/external/fossilize/cli/fossilize_replay_linux.hpp:1289:20: warning: ignoring return value of 'ssize_t read(int, void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
 1289 |        (void)::read(proc.watchdog_timer_fd, &dummy, sizeof(dummy));