### PR TITLE
cli & replayer: Add --device-pci-vendor and --device-pci-device options

### DIFF
--- a/cli/device.cpp
+++ b/cli/device.cpp
@@ -350,6 +350,9 @@ bool VulkanDevice::init_device(const Options &opts)
 	if (vkEnumeratePhysicalDevices(instance, &gpu_count, gpus.data()) != VK_SUCCESS)
 		return false;
 
+	int selected_gpu_index = -1;
+	bool pci_filter_set = opts.device_pci_vendor != 0;
+	bool pci_filter_matched = false;
 	for (uint32_t i = 0; i < gpu_count; i++)
 	{
 		vkGetPhysicalDeviceProperties(gpus[i], &gpu_props);
@@ -359,9 +362,32 @@ bool VulkanDevice::init_device(const Options &opts)
 		     VK_VERSION_MAJOR(gpu_props.apiVersion),
 		     VK_VERSION_MINOR(gpu_props.apiVersion),
 		     VK_VERSION_PATCH(gpu_props.apiVersion));
+		LOGI("  vendorID: 0x%x\n", gpu_props.vendorID);
+		LOGI("  deviceID: 0x%x\n", gpu_props.deviceID);
+
+		if (gpu_props.vendorID == opts.device_pci_vendor)
+		{
+			if (opts.device_pci_device == 0 || gpu_props.deviceID == opts.device_pci_device)
+			{
+				selected_gpu_index = i;
+				pci_filter_matched = true;
+				break;
+			}
+		}
 	}
 
-	if (opts.device_index >= 0)
+	if (pci_filter_set && !pci_filter_matched)
+	{
+		LOGW("No GPU matched --device-pci-vendor 0x%x%s; falling back to default selection.\n",
+		     opts.device_pci_vendor,
+		     opts.device_pci_device ? " (with --device-pci-device)" : "");
+	}
+
+	if (selected_gpu_index >= 0)
+	{
+		gpu = gpus[selected_gpu_index];
+	}
+	else if (opts.device_index >= 0)
 	{
 		if (size_t(opts.device_index) >= gpus.size())
 		{

--- a/cli/device.hpp
+++ b/cli/device.hpp
@@ -38,6 +38,8 @@ public:
 		bool null_device = false;
 		bool want_pipeline_stats = false;
 		int device_index = -1;
+		unsigned device_pci_vendor = 0;
+		unsigned device_pci_device = 0;
 		const VkApplicationInfo *application_info = nullptr;
 		const VkPhysicalDeviceFeatures2 *features = nullptr;
 	};

--- a/cli/fossilize_replay.cpp
+++ b/cli/fossilize_replay.cpp
@@ -3637,6 +3637,8 @@ static void print_help()
 	LOGI("fossilize-replay\n"
 	     "\t[--help]\n"
 	     "\t[--device-index <index>]\n"
+	     "\t[--device-pci-vendor <vendorID_hex>]\n"
+	     "\t[--device-pci-device <deviceID_hex>]\n"
 	     "\t[--enable-validation]\n"
 	     "\t[--enable-pipeline-stats <path>]\n"
 	     "\t[--spirv-val]\n"
@@ -4599,6 +4601,12 @@ int main(int argc, char *argv[])
 	cbs.default_handler = [&](const char *arg) { databases.push_back(arg); };
 	cbs.add("--help", [](CLIParser &parser) { print_help(); parser.end(); });
 	cbs.add("--device-index", [&](CLIParser &parser) { opts.device_index = parser.next_uint(); });
+	cbs.add("--device-pci-vendor", [&](CLIParser &parser) {
+		opts.device_pci_vendor = strtoul(parser.next_string(), nullptr, 0);
+	});
+	cbs.add("--device-pci-device", [&](CLIParser &parser) {
+		opts.device_pci_device = strtoul(parser.next_string(), nullptr, 0);
+	});
 	cbs.add("--enable-validation", [&](CLIParser &) { opts.enable_validation = true; });
 	cbs.add("--spirv-val", [&](CLIParser &) { replayer_opts.spirv_validate = true; });
 	cbs.add("--on-disk-pipeline-cache", [&](CLIParser &parser) { replayer_opts.on_disk_pipeline_cache_path = parser.next_string(); });

--- a/fossilize_external_replayer.hpp
+++ b/fossilize_external_replayer.hpp
@@ -107,6 +107,10 @@ public:
 		// Maps to --device-index.
 		unsigned device_index;
 
+		// Maps to --device-pci-vendor and --device-pci-device.
+		unsigned device_pci_vendor;
+		unsigned device_pci_device;
+
 		// Carve out a range of which pipelines to replay if use_pipeline_range is set.
 		// Used for multi-process replays where each process gets its own slice to churn through.
 		unsigned start_graphics_index;

--- a/fossilize_external_replayer_linux.hpp
+++ b/fossilize_external_replayer_linux.hpp
@@ -705,6 +705,21 @@ void ExternalReplayer::Impl::start_replayer_process(const ExternalReplayer::Opti
 	sprintf(index_name, "%u", options.device_index);
 	argv.push_back(index_name);
 
+	char pci_vendor_name[16], pci_device_name[16];
+	if (options.device_pci_vendor != 0)
+	{
+		argv.push_back("--device-pci-vendor");
+		sprintf(pci_vendor_name, "0x%x", options.device_pci_vendor);
+		argv.push_back(pci_vendor_name);
+	}
+
+	if (options.device_pci_device != 0)
+	{
+		argv.push_back("--device-pci-device");
+		sprintf(pci_device_name, "0x%x", options.device_pci_device);
+		argv.push_back(pci_device_name);
+	}
+
 	char graphics_range_start[16], graphics_range_end[16];
 	char compute_range_start[16], compute_range_end[16];
 	char raytracing_range_start[16], raytracing_range_end[16];

--- a/fossilize_external_replayer_windows.hpp
+++ b/fossilize_external_replayer_windows.hpp
@@ -586,6 +586,19 @@ bool ExternalReplayer::Impl::start(const ExternalReplayer::Options &options)
 	cmdline += " --device-index ";
 	cmdline += std::to_string(options.device_index);
 
+	char hex_buf[32];
+	if (options.device_pci_vendor != 0)
+	{
+		snprintf(hex_buf, sizeof(hex_buf), " --device-pci-vendor 0x%x", options.device_pci_vendor);
+		cmdline += hex_buf;
+	}
+
+	if (options.device_pci_device != 0)
+	{
+		snprintf(hex_buf, sizeof(hex_buf), " --device-pci-device 0x%x", options.device_pci_device);
+		cmdline += hex_buf;
+	}
+
 	if (options.enable_validation)
 		cmdline += " --enable-validation";
 


### PR DESCRIPTION
Draft PR. Open for review; not requesting merge yet.

## What this PR does

Adds `--device-pci-vendor <vendorID_hex>` and `--device-pci-device <deviceID_hex>`
to `fossilize-replay`, with a matching `ExternalReplayer::Options` pair so the
multi-process path can forward them. Selection walks the existing
`vkEnumeratePhysicalDevices` enumeration, logs `vendorID` and `deviceID` for
each candidate, picks the first GPU whose vendor matches and whose device
matches (if `--device-pci-device` is set), and falls back to `--device-index`
and finally `gpus.front()`.

On no-match, emits `LOGW("No GPU matched --device-pci-vendor 0x%x%s; ...")` so
callers learn the filter dropped out rather than silently landing on the wrong
GPU.

Windows `cmdline` uses `snprintf` + `0x%x` so the values round-trip as hex
through the CLI parser; Linux argv uses `sprintf` to match the existing
`index_name` pattern above it.

## Origin and relationship to PR #305

PR #305 bundled two unrelated concerns: `prctl(PR_SET_PDEATHSIG)` to kill
orphan replay workers, and PCI-based GPU selection. The prctl part landed
on master as `3efdda8` (squashed and stripped down by HansKristian-Work).
Per the same review comment, device filtering was invited as a separate PR.

This is that PR. No code from #305 is carried over other than the design idea.

## What does NOT conflict with subsequent work

- `a6a44aa` (Start adding a validation tool for GPU key invariance) —
  different concern. That tool tests cache key invariance across Vulkan
  implementations; this PR changes runtime device selection. No overlap.
- Robustness2 banlist (`96ae9b6`, `5b23748`, etc.) — orthogonal extension
  gating, not GPU selection.
- Bucket JSON system (`f0270fe`, `39004ff`, `5f95aa9`) — replay-time DB
  format; this PR is pre-init-device.
- Sifter CLI / roundtrip-checker (`2583ae3`,`, `c774839`) — new tools, no
  interaction with device enumeration.

## Where the responsibility actually lives

Selection of dGPU vs iGPU for shader compilation is typically the caller's
job:

- **DXVK** has its own `DXVK_FILTER_DEVICE_NAME` env var for matching by
  device name (see `doitsujin/dxvk`).
- **vkd3d-proton** has analogous device-name filtering at the D3D12 layer.
- **Steam Linux Runtime / pressure-vessel** exposes `PV_FORCE_USE_HWD`-style
  env vars that influence which Vulkan device the wrapper selects.
- **Mesa CI** could route through the new `fossilize-validate-cache-roundtrip`
  tool (`a6a44aa`) with this flag to pin the cache test to a specific ICD.

`fossilize-replay` is the right place for the flag because it's the lowest
layer that does enumeration; consumers that already decide the device
externally can ignore it, and consumers that don't can use it directly.
This PR provides the primitive, not the policy.

## Out of scope

- `--device-pci-domain` and `--device-pci-bus` for full `VK_EXT_pci_bus_info`
  matching — would help systems with multiple GPUs of the same vendorID +
  deviceID. Happy to add if asked; not in this PR to keep it atomic.
- A `pci_filter_matches()` predicate helper on `VulkanDevice` — inlined here
  to avoid scope creep. Easy to extract later if more callers need it.
- Tests. Held back per review feedback on #305 ("somewhat overzealous"); the
  synthetic test catalogue and 7-case matrix from the local branch are
  available if you want them landed separately.

## Validation

Tested on a 2-GPU hybrid laptop (AMD Renoir iGPU + NVIDIA RTX 3050 Mobile
dGPU), Vulkan 1.4.341, Mesa RADV RENOIR + NVIDIA proprietary 550.163.01,
against a real Steam pipeline cache (`/tmp/steam_pipeline_cache.snapshot.foz`,
83 MB, produced by `VK_LAYER_VALVE_steam_fossilize_32` — i.e. the actual
producer of foz files that this tool replays).

The host enumerates 3 physical-device candidates:

```
Enumerated GPU #0:
  name: AMD Radeon Graphics (RADV RENOIR)
  apiVersion: 1.4.354
  vendorID: 0x1002
  deviceID: 0x1636
Enumerated GPU #1:
  name: NVIDIA GeForce RTX 3050 Laptop GPU
  apiVersion: 1.3.277
  vendorID: 0x10de
  deviceID: 0x25a2
Enumerated GPU #2:
  vendorID: 0x10005    # Mesa venus / virtual device
  deviceID: 0x0
```

**Without filter** the loader picks `gpus.front()` (the AMD iGPU). For
shader-compilation workloads the dGPU is the correct target — shader
caches keyed on the iGPU are unusable on the dGPU and vice versa.

**With `--device-pci-vendor 0x10de`** the loader picks the NVIDIA dGPU:

```
Chose GPU:
  name: NVIDIA GeForce RTX 3050 Laptop GPU
  apiVersion: 1.3.277
  vendorID: 0x10de
  deviceID: 0x25a2
```

**With `--device-pci-vendor 0x1002`** it picks the AMD iGPU (matching
the vendorID but ignoring deviceID since not specified).

**With `--device-pci-vendor 0x10de --device-pci-device 0x25a2`** it picks
the specific NVIDIA dGPU.

**With `--device-pci-vendor 0xDEAD`** (no match) it logs the warning and
falls back to default:

```
Fossilize WARN: No GPU matched --device-pci-vendor 0xdead; falling back to default selection.
```

Hex round-trip verified: `strtoul("0x10de", NULL, 0)` produces `0x10de`,
which matches the `vendorID` byte-for-byte in the LOGI stream. The Windows
multi-process path uses `snprintf(..., "0x%x", ...)` so the same value
survives the cmdline round-trip.

Multi-process path (`--num-threads > 1`) confirmed to forward both flags
through `argv` on the same host: the child `slave-process` invocation
receives `--device-pci-vendor 0x10de` verbatim.

### Concrete consumer path (Steam Linux Runtime)

The foz file used above was produced by Steam's pipeline-cache layer
(`VK_LAYER_VALVE_steam_fossilize_32`). On Steam Linux Runtime 3.0
(`pressure-vessel`) the launch script sets `PV_FORCE_USE_HWD` and the
`SteamLinuxRuntime_*` env vars before invoking the game. For shader
compilation targets this PR lets the replayer's caller pin the dGPU
unambiguously by vendor, regardless of how the loader orders the ICDs
on a given hybrid host — which is otherwise up to the Mesa and NVIDIA
ICD init order and can change across driver updates.

### Mesa CI use case

Mesa CI recently added `fossilize-validate-cache-roundtrip` (`a6a44aa`)
which validates cache-key invariance across Vulkan implementations. With
this flag Mesa CI can pin each roundtrip run to a specific vendor
(NVIDIA vs RADV vs Intel vs Lavapipe) without depending on the
enumeration order of the runner image.

### Known limitation (out of scope here)

Hybrid hosts with two GPUs sharing `vendorID` + `deviceID` (rare but
real — e.g. multi-GPU workstations with twin RTX cards) need
`--device-pci-domain` / `--device-pci-bus` via `VK_EXT_pci_bus_info` to
disambiguate. Happy to add as a follow-up PR if requested; not included
here to keep scope atomic.

## Diff

```
 cli/device.cpp                          | 28 ++++++++++++++++++++++++++-
 cli/device.hpp                          |  2 ++
 cli/fossilize_replay.cpp                |  8 ++++++++
 fossilize_external_replayer.hpp         |  4 ++++
 fossilize_external_replayer_linux.hpp   | 15 +++++++++++++
 fossilize_external_replayer_windows.hpp | 13 ++++++++++++
 6 files changed, 69 insertions(+), 1 deletion(-)
```
